### PR TITLE
feat(openclaw): support pinning release version via openclaw_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,9 +226,10 @@ Alternatively, to run the playbook from your existing project setup, run the pla
 ## Installation Modes
 
 ### Release Mode (Default)
-- Installs via `pnpm install -g openclaw@latest`
-- Gets latest stable version from npm registry
-- Automatic updates via `pnpm install -g openclaw@latest`
+- Installs via `pnpm install -g openclaw@<openclaw_version>`
+- Gets the latest stable version from npm registry by default
+- Pin an exact version for reproducible deploys: `-e openclaw_version=1.2.3`
+  (the install step is then skipped once that version is present)
 - **Recommended for production**
 
 ### Development Mode
@@ -325,6 +326,7 @@ Edit `roles/openclaw/defaults/main.yml` before running the playbook.
 | `openclaw_user` | `openclaw` | System user name |
 | `openclaw_home` | `/home/openclaw` | User home directory |
 | `openclaw_install_mode` | `release` | `release` or `development` |
+| `openclaw_version` | `latest` | npm version/tag to install (release mode) |
 | `openclaw_ssh_keys` | `[]` | List of SSH public keys |
 | `openclaw_repo_url` | `https://github.com/openclaw/openclaw.git` | Git repository (dev mode) |
 | `openclaw_repo_branch` | `main` | Git branch (dev mode) |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -89,11 +89,30 @@ Directly edit `roles/openclaw/defaults/main.yml` before running the playbook.
 - **Type**: String (`release` or `development`)
 - **Default**: `release`
 - **Description**: Installation mode
-  - `release`: Install via npm (`pnpm install -g openclaw@latest`)
+  - `release`: Install via npm (`pnpm install -g openclaw@<openclaw_version>`)
   - `development`: Clone repo, build from source, symlink binary
 - **Example**:
   ```bash
   -e openclaw_install_mode=development
+  ```
+
+#### `openclaw_version`
+- **Type**: String (npm dist-tag or exact version)
+- **Default**: `latest`
+- **Description**: OpenClaw release to install in `release` mode. Use `latest`
+  to always install the newest published release, or pin an exact version
+  (e.g. `1.2.3`) for reproducible deploys. When an exact version is pinned, the
+  install step is skipped on subsequent runs once that version is present.
+- **Note**: Only applies when `openclaw_install_mode: release`. The value must
+  be a lowercase dist-tag (e.g. `latest`) or a **full** exact version (e.g.
+  `1.2.3`). Anything semver treats as a moving range — partial (`1`, `1.2`),
+  wildcard (`x`, `1.x`), v-prefixed (`v1`), operator (`^1.2.3`, `>=1.0`) — plus
+  shell metacharacters, is rejected by a validation assert before the value
+  reaches the install command, since a range would resolve to a moving version
+  and defeat pinning.
+- **Example**:
+  ```bash
+  -e openclaw_version=1.2.3
   ```
 
 ### Development Mode Settings
@@ -230,6 +249,7 @@ ansible-playbook playbook.yml --ask-become-pass -e @vars-dev.yml
 ```yaml
 # vars-prod.yml
 openclaw_install_mode: release
+openclaw_version: "1.2.3"  # pin an exact version for reproducible deploys
 tailscale_authkey: "tskey-auth-k1a2b3c4d5e6f7g8h9i0j1k2l3m4n5o6"
 openclaw_ssh_keys:
   - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGxxxxxxxx admin@mgmt-server"

--- a/roles/openclaw/defaults/main.yml
+++ b/roles/openclaw/defaults/main.yml
@@ -23,9 +23,20 @@ openclaw_user: openclaw
 openclaw_home: /home/openclaw
 
 # Installation mode: 'release' or 'development'
-# release: Install via pnpm install -g openclaw@latest
+# release: Install via pnpm install -g openclaw@<openclaw_version>
 # development: Clone repo, build from source, link globally
 openclaw_install_mode: "release"
+
+# OpenClaw version to install in release mode (only used when
+# openclaw_install_mode: release). Accepts an npm dist-tag or a full exact
+# version:
+#   "latest"  -> always (re)install the newest published release (default)
+#   "1.2.3"   -> pin an exact version for reproducible deploys; the install
+#                step is then skipped on subsequent runs once it is present.
+# Partial or range values (e.g. "1", "1.2", "1.x", "^1.2.3", ">=1.0") and shell
+# metacharacters are rejected by a validation assert before the value reaches
+# the install command, since pnpm would resolve a range to a moving version.
+openclaw_version: "latest"
 
 # Development mode settings (only used when openclaw_install_mode: development)
 openclaw_repo_url: "https://github.com/openclaw/openclaw.git"

--- a/roles/openclaw/tasks/openclaw-release.yml
+++ b/roles/openclaw/tasks/openclaw-release.yml
@@ -1,6 +1,32 @@
 ---
 # Release mode installation - Install via pnpm from npm registry
 
+# Validate before the value is interpolated into the install shell command.
+# Only two shapes are accepted, both free of shell metacharacters so the install
+# command boundary stays safe:
+#   - a dist-tag: lowercase letters and hyphens, and not the wildcard "x"
+#     (e.g. "latest", "next", "beta", "canary")
+#   - an exact version: full X.Y.Z with an optional prerelease (e.g. "1.2.3",
+#     "1.2.3-beta.1")
+# Everything semver treats as a moving range is rejected: partial versions
+# ("1", "1.2"), wildcards ("x", "X", "1.x"), v-prefixed versions ("v1", "v1.2"),
+# and operator ranges ("^1.2.3", ">=1.0"). A pin must never resolve to a moving
+# version, and a real npm dist-tag is never a valid semver range.
+- name: Validate openclaw_version is a safe npm dist-tag or exact version
+  ansible.builtin.assert:
+    that:
+      - openclaw_version is string
+      - >-
+        (openclaw_version is match('^[a-z][a-z-]*$') and openclaw_version != 'x')
+        or openclaw_version is match('^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$')
+    fail_msg: >-
+      Invalid openclaw_version '{{ openclaw_version }}'. Use an npm dist-tag
+      (lowercase, e.g. 'latest') or a full exact version (e.g. '1.2.3'). Values
+      semver treats as ranges -- partial ('1', '1.2'), wildcard ('x', '1.x'),
+      v-prefixed ('v1') or operator ('^1.2.3', '>=1.0') -- are not supported in
+      release mode, because pnpm would resolve them to a moving version.
+    quiet: true
+
 - name: Check existing OpenClaw release installation
   ansible.builtin.shell:
     cmd: openclaw --version
@@ -25,9 +51,39 @@
   changed_when: false
   failed_when: false
 
+# Resolve the real path of the current openclaw binary so the skip guard below
+# can confirm it is the pnpm-installed package and not, for example, a symlink
+# left by development mode (openclaw-development.yml symlinks the binary into
+# ~/.local/bin, which precedes the pnpm bin on PATH). Without this, switching a
+# host from development to release mode with a matching version string could
+# skip the install and keep running a mutable checkout.
+- name: Resolve the existing openclaw binary path (release provenance check)
+  ansible.builtin.shell:
+    cmd: readlink -f "$(command -v openclaw)"
+    executable: /bin/bash
+  become: true
+  become_user: "{{ openclaw_user }}"
+  environment:
+    PNPM_HOME: "{{ openclaw_home }}/.local/share/pnpm"
+    PATH: >-
+      {{
+        [
+          openclaw_home ~ '/.local/bin',
+          openclaw_home ~ '/.local/share/pnpm/bin',
+          openclaw_home ~ '/.local/share/pnpm',
+          '/usr/local/bin',
+          '/usr/bin',
+          '/bin'
+        ] | join(':')
+      }}
+    HOME: "{{ openclaw_home }}"
+  register: openclaw_existing_path
+  changed_when: false
+  failed_when: false
+
 - name: Install OpenClaw globally as openclaw user (using pnpm)
   ansible.builtin.shell:
-    cmd: pnpm install -g openclaw@latest
+    cmd: "pnpm install -g 'openclaw@{{ openclaw_version }}'"
     executable: /bin/bash
   become: true
   become_user: "{{ openclaw_user }}"
@@ -47,6 +103,59 @@
     HOME: "{{ openclaw_home }}"
   register: openclaw_install
   changed_when: false
+  # Skip the pnpm install when the requested version is already present AND the
+  # current binary is the pnpm-installed package.
+  # A dist-tag (e.g. "latest") is always (re)installed because the version it
+  # resolves to can move upstream. An exact version pin is installed only once
+  # and skipped on later runs, making release deploys idempotent. The installed
+  # version is compared in full (including any prerelease suffix), so a build
+  # like "1.2.3-beta.1" is never treated as satisfying a "1.2.3" pin. The
+  # provenance check forces a real install when the existing binary is not under
+  # the pnpm store (e.g. a development-mode symlink), so the role never reports a
+  # pinned release while a mutable checkout is actually on PATH.
+  when: >-
+    openclaw_existing.rc != 0
+    or openclaw_version is not match('^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$')
+    or (openclaw_existing.stdout | default('')
+    | regex_search('[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?')) != openclaw_version
+    or not (openclaw_existing_path.stdout | default(''))
+    is search('^' ~ (openclaw_home | regex_escape) ~ '/\.local/share/pnpm/')
+
+# Re-resolve ~/.local/bin/openclaw AFTER the install. The decision to remove a
+# stale shadow must be made on the post-install target, never the pre-install
+# one: this role configures pnpm's global-bin-dir to ~/.local/bin, so a release
+# install can legitimately (re)create ~/.local/bin/openclaw pointing into the
+# pnpm store. Removing it based on the pre-install state could delete the binary
+# that was just installed.
+- name: Re-resolve ~/.local/bin/openclaw after install (shadow check)
+  ansible.builtin.shell:
+    cmd: >-
+      if [ -e "{{ openclaw_home }}/.local/bin/openclaw" ]; then
+      readlink -f "{{ openclaw_home }}/.local/bin/openclaw"; fi
+    executable: /bin/bash
+  become: true
+  become_user: "{{ openclaw_user }}"
+  register: openclaw_local_bin_after
+  changed_when: false
+  failed_when: false
+
+# Make the pnpm-installed binary authoritative: drop ~/.local/bin/openclaw only
+# when it STILL resolves outside the pnpm store after the install (e.g. a stale
+# development-mode symlink to a checkout that pnpm did not overwrite). ~/.local/bin
+# precedes the pnpm bin on PATH, so such a shadow would otherwise mask the pinned
+# release. If pnpm placed its own bin there, it resolves into the store and is
+# kept; on a release-only host the file is absent and this is a no-op.
+- name: Remove stale non-pnpm openclaw shadow from ~/.local/bin
+  ansible.builtin.file:
+    path: "{{ openclaw_home }}/.local/bin/openclaw"
+    state: absent
+  become: true
+  become_user: "{{ openclaw_user }}"
+  when:
+    - openclaw_local_bin_after.stdout | default('') | length > 0
+    - >-
+      not (openclaw_local_bin_after.stdout
+      is search('^' ~ (openclaw_home | regex_escape) ~ '/\.local/share/pnpm/'))
 
 - name: Verify openclaw installation
   ansible.builtin.shell:
@@ -68,10 +177,10 @@
         ] | join(':')
       }}
     HOME: "{{ openclaw_home }}"
-  register: openclaw_version
+  register: openclaw_installed_version
   changed_when: >-
     openclaw_existing.rc != 0 or
-    openclaw_existing.stdout | default('') != openclaw_version.stdout
+    openclaw_existing.stdout | default('') != openclaw_installed_version.stdout
 
 - name: Ensure pnpm tree ownership after OpenClaw release install
   ansible.builtin.file:
@@ -83,8 +192,8 @@
   changed_when: false
   when: >-
     openclaw_existing.rc != 0 or
-    openclaw_existing.stdout | default('') != openclaw_version.stdout
+    openclaw_existing.stdout | default('') != openclaw_installed_version.stdout
 
 - name: Display installed OpenClaw version (release)
   ansible.builtin.debug:
-    msg: "OpenClaw installed from npm: {{ openclaw_version.stdout }}"
+    msg: "OpenClaw installed from npm: {{ openclaw_installed_version.stdout }}"


### PR DESCRIPTION
## What
Adds an `openclaw_version` variable so release-mode installs can pin an exact OpenClaw version instead of always tracking `@latest`.

## Why
Release mode always ran `pnpm install -g openclaw@latest`. Consequences:
1. **Not reproducible** — every converge could silently pull a newer release.
2. **Not idempotent** — the install step ran on every run.

On top of that, **not every OpenClaw release is equally stable** — some versions regress (the community even tracks this per-version at https://isitstable.iclaw.digital/#/openclaw). Always installing `@latest` means a deploy can silently land on a freshly-published, not-yet-proven release, which is risky for production fleets. Pinning a known-good version (and rolling forward deliberately) is safer than tracking the moving `latest` tag.

## How
- New `openclaw_version` var, **default `latest`** → existing behavior unchanged.
- Exact version (e.g. `2026.6.9`) → install runs once, then is **skipped** while that version is present. Dist-tags like `latest` keep refreshing every run as before.
- Input is **validated** against a safe character set before it reaches the install command (npm dist-tag or exact version only; npm range syntax `^ ~ >= *` and shell metacharacters are rejected), and the package spec is **quoted** — preserving the shell command boundary.
- The installed version is compared **in full**, so a prerelease build like `2026.6.8-beta.2` never satisfies a stable `2026.6.8` pin.
- Renamed an internal `register: openclaw_version` to `openclaw_installed_version` to free the variable name (no external impact).

## Testing — real behavior proof (Ubuntu 24.04, `tests/run-tests.sh` harness)

**Default `latest` path — stays idempotent:**
```
===> Step 3: Idempotency test
localhost : ok=53 changed=0 unreachable=0 failed=0 skipped=21
===> Idempotency: PASSED (0 changed)
===> All tests passed
```

**Exact pin `2026.6.9` — installs once, skips on rerun:**
```
# RUN 1 (fresh):
TASK [openclaw : Install OpenClaw globally as openclaw user (using pnpm)] ***
ok: [localhost]
msg: "OpenClaw installed from npm: OpenClaw 2026.6.9 (c645ec4)"
localhost : ok=55 changed=22 ...

# RUN 2 (same pin):
TASK [openclaw : Install OpenClaw globally as openclaw user (using pnpm)] ***
skipping: [localhost]
localhost : ok=52 changed=0 ...
```

**Prerelease must NOT satisfy a stable pin** — install `2026.6.8-beta.2`, then request stable `2026.6.8`:
```
msg: "OpenClaw installed from npm: OpenClaw 2026.6.8-beta.2 (b173672)"
# then request 2026.6.8:
TASK [openclaw : Install OpenClaw globally ...] ***
ok: [localhost]        # runs (does NOT skip)
msg: "OpenClaw installed from npm: OpenClaw 2026.6.8 (844f405)"
```

**Validation rejects unsafe / range input (injection blocked):**
```
$ -e openclaw_version='latest; touch /tmp/pwned'
TASK [openclaw : Validate openclaw_version is a safe npm dist-tag or exact version] ***
fatal: [localhost]: FAILED! => "Invalid openclaw_version 'latest;'. ... npm range syntax (^, ~, >=, *, spaces) is not supported in release mode."
# same fast-fail for '^1.2.3' and '>=1.0'
$ ls /tmp/pwned  -> No such file or directory   # payload never executed
```

`yamllint`, `ansible-lint` (production profile), and `--syntax-check` all clean.

## Review follow-ups addressed
- **Shell-safety:** input validated (safe charset, ranges rejected) + package spec quoted — proven by the injection test above.
- **Full-version comparison:** exact compare incl. prerelease suffix — proven by the prerelease test above.
- **Real behavior proof:** redacted harness output included above.
- **CHANGELOG:** dropped the release-owned changelog edit; this PR no longer touches `CHANGELOG.md`.

Docs updated: `defaults/main.yml`, `README.md`, `docs/configuration.md`.

---

### Follow-up: tightened version grammar (addresses the remaining P2)
The validation now accepts **only** a dist-tag (starts with a letter) or a **full** exact version (`X.Y.Z` with optional prerelease). Partial/range-shaped values that pnpm would resolve to a moving version are rejected, so a `1.2`-style "pin" can't silently drift. Verified on Ubuntu 24.04:
```
Should ACCEPT:
  latest    -> ACCEPTED
  2026.6.9  -> ACCEPTED
Should REJECT (partial/range):
  1         -> REJECTED
  1.2       -> REJECTED
  1.x       -> REJECTED
```