### PR TITLE
feat: add Fedora/RHEL-family platform support with rootless Podman

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,186 +2,197 @@
 
 ## Project Overview
 
-Ansible playbook for automated, hardened OpenClaw installation on Debian/Ubuntu systems.
+Ansible playbook for automated, hardened OpenClaw installation on Linux servers.
+
+Supported platform families:
+
+- Debian/Ubuntu: UFW + Docker CE + Compose V2.
+- Fedora/RHEL family: firewalld + rootless Podman + rootless Quadlets only.
 
 ## Key Principles
 
-1. **Security First**: Firewall must be configured before Docker installation
-2. **One Command Install**: `curl | bash` should work out of the box
-3. **Localhost Only**: All container ports bind to 127.0.0.1
-4. **Defense in Depth**: UFW + DOCKER-USER + localhost binding + non-root container
+1. **Security First**: configure firewall and runtime isolation before exposing services.
+2. **One Command Install**: `curl | bash` should work on supported platforms.
+3. **Localhost Only**: container-published ports bind to `127.0.0.1` unless explicitly documented otherwise.
+4. **OS-Native Runtime**: Debian keeps Docker; RedHat-family uses rootless Podman only.
+5. **No Rootful Podman**: never implement or suggest rootful Podman fallback.
 
 ## Critical Components
 
 ### Task Order
-Docker must be installed **before** firewall configuration.
 
 Task order in `roles/openclaw/tasks/main.yml`:
+
 ```yaml
-- tailscale.yml  # VPN setup
-- user.yml       # Create system user
-- docker.yml     # Install Docker (creates /etc/docker)
-- firewall.yml   # Configure UFW + daemon.json (needs /etc/docker to exist)
-- nodejs.yml     # Node.js + pnpm
-- openclaw.yml   # Container setup
+- preflight.yml          # OS vars, support checks, rootless policy
+- system-tools.yml       # OS-family package map
+- tailscale-*.yml        # optional VPN setup
+- user.yml               # app user and user-systemd env
+- docker-linux.yml       # Debian/Ubuntu only
+- podman-redhat.yml      # RedHat-family rootless setup only
+- firewall-linux.yml     # Debian/Ubuntu UFW + DOCKER-USER
+- firewall-redhat.yml    # RedHat-family firewalld
+- nodejs.yml             # OS-family NodeSource setup
+- openclaw.yml           # OpenClaw install/state dirs
+- quadlet-redhat.yml     # RedHat-family rootless Quadlet only
 ```
 
-Reason: `firewall.yml` writes `/etc/docker/daemon.json` and restarts Docker service.
+### Debian/Ubuntu Runtime
 
-### DOCKER-USER Chain
-Located in `/etc/ufw/after.rules`. Uses dynamic interface detection (not hardcoded `eth0`).
+- Docker must be installed before Debian firewall configuration because `firewall-linux.yml` writes `/etc/docker/daemon.json` and restarts Docker.
+- DOCKER-USER rules live in `/etc/ufw/after.rules` and must use dynamic interface detection.
+- Never use `iptables: false` in Docker daemon config.
+- Keep Docker port bindings on `127.0.0.1`.
 
-**Never** use `iptables: false` in Docker daemon config - this would break container networking.
+### Fedora/RHEL Runtime
 
-### Port Binding
-Always use `127.0.0.1:HOST_PORT:CONTAINER_PORT` in docker-compose.yml, never `HOST_PORT:CONTAINER_PORT`.
+- Use `dnf`/`yum`-compatible packages and RedHat package names.
+- Use `firewalld`, not UFW.
+- Use `podman`, not Docker.
+- Rootless Podman only. Rootful Podman must fail fast.
+- Rootless Quadlets only under `/home/{{ openclaw_user }}/.config/containers/systemd/`.
+- Never write OpenClaw Quadlets under system Quadlet directories.
+- Manage services with `systemctl --user` as `{{ openclaw_user }}` and set `XDG_RUNTIME_DIR=/run/user/{{ openclaw_uid_value }}`.
+- Keep SELinux enabled. Use `:Z` labels for private OpenClaw bind mounts.
 
 ## Code Style
 
 ### Ansible
-- Use loops instead of repeated tasks
-- No `become_user` (playbook already runs as root)
-- Use `community.docker.docker_compose_v2` (not deprecated `docker_compose`)
-- Always specify collections in `requirements.yml`
+
+- Use loops instead of repeated tasks.
+- Prefer modules over shell/command when modules are safe.
+- Shell/command tasks need accurate `changed_when`.
+- Keep OS-specific behavior isolated by vars/tasks.
+- Always specify collections in `requirements.yml`.
 
 ### Docker
-- Multi-stage builds if needed
-- USER directive for non-root
-- Proper healthchecks (test the app, not just Node)
-- Use `docker compose` (V2) not `docker-compose` (V1)
-- No `version:` in compose files
 
-### Templates
-- Use variables for all paths/ports
-- Add comments explaining security decisions
-- Keep jinja2 logic simple
+- Debian/Ubuntu only.
+- Use `docker compose` V2, not deprecated `docker-compose` V1.
+- No `version:` in compose files.
+
+### Podman
+
+- RedHat-family only in this installer.
+- Use rootless Quadlet files.
+- Do not enable rootful `podman.service` or `podman.socket`.
+- Do not add a `docker` group on RedHat-family systems.
 
 ## Testing Checklist
 
 Before committing changes:
 
 ```bash
-# 1. Syntax check
 ansible-playbook playbook.yml --syntax-check
+ansible-playbook playbooks/deploy.yml --syntax-check
+ansible-playbook tests/verify.yml --syntax-check
+ansible-playbook tests/verify-redhat-static.yml --syntax-check
+ansible-playbook tests/verify-redhat-static.yml
+ansible-lint playbook.yml
+yamllint .
+```
 
-# 2. Dry run
-ansible-playbook playbook.yml --check
+Platform validation on disposable hosts:
 
-# 3. Full install (on test VM)
-curl -fsSL https://raw.githubusercontent.com/.../install.sh | bash
-
-# 4. Verify security
+```bash
+# Debian/Ubuntu
 sudo ufw status verbose
 sudo iptables -L DOCKER-USER -n
-sudo ss -tlnp  # Only SSH + localhost should listen
-
-# 5. External port scan
-nmap -p- TEST_SERVER_IP  # Only port 22 should be open
-
-# 6. Test isolation
+sudo ss -tlnp
 sudo docker run -p 80:80 nginx
-curl http://TEST_SERVER_IP:80  # Should fail
-curl http://localhost:80        # Should work
+
+# Fedora/RHEL family
+sudo firewall-cmd --state
+sudo firewall-cmd --list-all
+sudo su - openclaw
+loginctl show-user openclaw
+podman info --format '{{.Host.Security.Rootless}}'
+systemctl --user status openclaw.service
+journalctl --user -u openclaw.service -n 100
+test ! -e /etc/containers/systemd/openclaw.container
 ```
 
 ## Common Mistakes to Avoid
 
-1. ❌ Installing Docker before configuring firewall
-2. ❌ Using `0.0.0.0` port binding
-3. ❌ Hardcoding network interface names (use dynamic detection)
-4. ❌ Setting `iptables: false` in Docker daemon
-5. ❌ Running container as root
-6. ❌ Using deprecated `docker-compose` (V1)
-7. ❌ Forgetting to add collections to requirements.yml
+1. ❌ Regressing Debian/Ubuntu Docker + UFW behavior.
+2. ❌ Installing Docker or creating a `docker` group on RedHat-family systems.
+3. ❌ Using rootful Podman or adding rootful fallback.
+4. ❌ Writing Quadlets to system Quadlet directories.
+5. ❌ Running RedHat-family Quadlet commands with system-level `systemctl`.
+6. ❌ Disabling SELinux.
+7. ❌ Hardcoding network interface names.
+8. ❌ Using `0.0.0.0` port bindings.
 
 ## Documentation
 
-### User-Facing
-- **README.md**: Installation, quick start, basic management
-- **docs/**: Technical details, architecture, troubleshooting
+- **README.md**: installation, quick start, supported matrix.
+- **docs/**: architecture, security, troubleshooting.
+- **AGENTS.md**: this file.
 
-### Developer-Facing
-- **AGENTS.md**: This file - guidelines for AI agents/contributors
-- Code comments: Explain *why*, not *what*
-
-Keep docs concise. No progress logs, no refactoring summaries.
+Keep docs concise. No progress logs or refactoring summaries.
 
 ## File Locations
 
 ### Host System
-```
-/opt/openclaw/              # Installation files
-/home/openclaw/.openclaw/   # Config and data
-/etc/systemd/system/openclaw.service
-/etc/docker/daemon.json
-/etc/ufw/after.rules
+
+```text
+/opt/openclaw/                                      # Installation files when source mode uses it
+/home/openclaw/.openclaw/                          # Config and data
+/etc/docker/daemon.json                            # Debian/Ubuntu only
+/etc/ufw/after.rules                               # Debian/Ubuntu only
+/home/openclaw/.config/containers/systemd/         # RedHat-family rootless Quadlets
 ```
 
 ### Repository
-```
-roles/openclaw/
-├── tasks/       # Ansible tasks (order matters!)
-├── templates/   # Jinja2 configs
-├── defaults/    # Variables
-└── handlers/    # Service restart handlers
 
-docs/            # Technical documentation (frontmatter format)
-requirements.yml # Ansible Galaxy collections
+```text
+roles/openclaw/
+├── tasks/       # Ansible tasks
+├── templates/   # Jinja2 configs and Quadlets
+├── defaults/    # Shared defaults
+├── vars/        # OS-family variables
+└── handlers/    # Service restart handlers
 ```
 
 ## Security Notes
 
-### Why UFW + DOCKER-USER?
-Docker bypasses UFW by default. DOCKER-USER chain is evaluated first, allowing us to block before Docker sees the traffic.
+### Why UFW + DOCKER-USER on Debian/Ubuntu?
+
+Docker bypasses UFW by default. DOCKER-USER is evaluated first, allowing the installer to block forwarded traffic before Docker sees it.
+
+### Why firewalld + rootless Podman on RedHat-family systems?
+
+firewalld, SELinux, and rootless Podman are the native RedHat-family stack. Rootless Quadlets keep container lifecycle under the app user's systemd manager instead of a rootful daemon.
 
 ### Why Fail2ban?
-SSH is exposed to the internet. Fail2ban automatically bans IPs after 5 failed attempts for 1 hour.
 
-### Why Unattended-Upgrades?
-Security patches should be applied promptly. Automatic security-only updates reduce vulnerability windows.
+SSH is exposed to the internet. Fail2ban automatically bans IPs after repeated failed attempts on Debian/Ubuntu.
 
 ### Why Scoped Sudo?
-The openclaw user only needs to manage its own service and Tailscale. Full root access would be dangerous if the app is compromised.
 
-### Why Localhost Binding?
-Defense in depth. If DOCKER-USER fails, localhost binding prevents external access.
-
-### Why Non-Root Container?
-Least privilege. Limits damage if container is compromised.
-
-### Why Systemd?
-Clean lifecycle, auto-start, logging integration.
-
-### Known Limitations
-- **macOS**: Incomplete support (no launchd, basic firewall). Test thoroughly.
-- **IPv6**: Disabled in Docker. Review if your network uses IPv6.
-- **curl | bash**: Inherent risks. For production, clone and audit first.
+The `openclaw` user only needs limited service and Tailscale commands. Full root access would be dangerous if the app is compromised.
 
 ## Making Changes
 
 ### Adding a New Task
-1. Add to appropriate file in `roles/openclaw/tasks/`
-2. Update main.yml if new task file
-3. Test with `--check` first
-4. Verify idempotency (can run multiple times safely)
+
+1. Add to the appropriate OS-family task file.
+2. Update `roles/openclaw/tasks/main.yml` only if a new task file is needed.
+3. Add OS-family vars when package names or runtime behavior differ.
+4. Test with `--syntax-check` first.
+5. Verify idempotency on a disposable host.
 
 ### Changing Firewall Rules
-1. Test on disposable VM first
-2. Always keep SSH accessible
-3. Update `docs/security.md` with changes
-4. Verify with external port scan
 
-### Updating Docker Config
-1. Changes to `daemon.json.j2` trigger Docker restart (via handler)
-2. Test container networking after restart
-3. Verify DOCKER-USER chain still works
+1. Test on a disposable VM first.
+2. Always keep SSH accessible.
+3. Update `docs/security.md`.
+4. Verify with an external port scan.
 
-## Version Management
+### Updating Runtime Config
 
-- Use semantic versioning for releases
-- Tag releases in git
-- Update CHANGELOG.md with user-facing changes
-- No version numbers in code (use git tags)
+- Debian/Ubuntu: changes to `daemon.json.j2` trigger Docker restart.
+- RedHat-family: changes to `openclaw.container.j2` require user daemon reload and user service restart.
 
 ## Support Channels
 

--- a/README.md
+++ b/README.md
@@ -5,29 +5,45 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Lint](https://github.com/openclaw/openclaw-ansible/actions/workflows/lint.yml/badge.svg)](https://github.com/openclaw/openclaw-ansible/actions/workflows/lint.yml)
 [![Ansible](https://img.shields.io/badge/Ansible-2.14+-blue.svg)](https://www.ansible.com/)
-[![Multi-OS](https://img.shields.io/badge/OS-Debian%20%7C%20Ubuntu-orange.svg)](https://www.debian.org/)
+[![Multi-OS](https://img.shields.io/badge/OS-Debian%20%7C%20Ubuntu%20%7C%20Fedora%20%7C%20RHEL--family-orange.svg)](https://www.ansible.com/)
 
-Automated, hardened installation of [OpenClaw](https://github.com/openclaw/openclaw) with Docker and Tailscale VPN support for Debian/Ubuntu Linux.
+Automated, hardened installation of [OpenClaw](https://github.com/openclaw/openclaw) with OS-native firewall and container runtime support.
 
-## ⚠️ macOS Support: Deprecated & Disabled
+## Supported platforms
 
-**Effective 2026-02-06, support for bare-metal macOS installations has been removed from this playbook.**
+| Platform | Version | Firewall | Container runtime |
+| --- | --- | --- | --- |
+| Debian | 11+ | UFW | Docker CE + Compose V2 |
+| Ubuntu | 20.04+ | UFW | Docker CE + Compose V2 |
+| Fedora | 38+ | firewalld | rootless Podman + rootless Quadlets |
+| RHEL, CentOS Stream, AlmaLinux, Rocky Linux, Oracle Linux | 9+ | firewalld | rootless Podman + rootless Quadlets |
 
-### Why?
-The underlying project currently requires system-level permissions and configurations that introduce significant security risks when executed on a primary host OS. To protect user data and system integrity, we have disabled bare-metal execution.
+CentOS 7 and RHEL-family 7/8 are unsupported because this installer requires rootless Podman Quadlets on RedHat-family systems.
 
-### What does this mean?
-* The playbook will now explicitly fail if run on a `Darwin` (macOS) system.
-* We strongly discourage manual workarounds to bypass this check.
-* **Future Support:** We are evaluating a virtualization-first strategy (using Vagrant or Docker) to provide a sandboxed environment for this project in the future.
+## RedHat-family security model
+
+Fedora, RHEL, CentOS Stream, AlmaLinux, Rocky Linux, and Oracle Linux installs use the native RedHat-family stack:
+
+- `dnf`/`yum` packages, not Debian package names
+- `firewalld`, not UFW
+- `podman`, not Docker
+- rootless Podman only
+- rootless Quadlets only, written to `/home/<app-user>/.config/containers/systemd/`
+- SELinux-compatible bind mounts with private `:Z` labels
+
+Rootful Podman is intentionally unsupported. The playbook fails instead of starting rootful Podman services, using system Quadlet directories, or falling back to Docker on RedHat-family systems.
+
+## macOS support is disabled
+
+Bare-metal macOS installs are disabled. Use a Linux VM or server instead.
 
 ## Features
 
-- 🔒 **Firewall-first**: UFW firewall + Docker isolation
-- 🛡️ **Fail2ban**: SSH brute-force protection out of the box
-- 🔄 **Auto-updates**: Automatic security patches via unattended-upgrades
+- 🔒 **Firewall-first**: UFW on Debian/Ubuntu; firewalld on Fedora/RHEL-family systems
+- 🛡️ **Fail2ban**: SSH brute-force protection on Debian/Ubuntu
+- 🔄 **Auto-updates**: Automatic security patches via unattended-upgrades on Debian/Ubuntu
 - 🔐 **Tailscale VPN**: Secure remote access without exposing services
-- 🐳 **Docker**: Docker CE with security hardening
+- 🐳 **Container runtime**: Docker on Debian/Ubuntu; rootless Podman Quadlets on Fedora/RHEL-family systems
 - 🚀 **One-command install**: Complete setup in minutes
 - 🔧 **Auto-configuration**: DBus, systemd, environment setup
 - 📦 **pnpm installation**: Uses `pnpm install -g openclaw@latest`
@@ -57,12 +73,13 @@ cd openclaw-ansible
 
 ## What Gets Installed
 
-- Tailscale (mesh VPN)
-- UFW firewall (SSH + Tailscale ports only)
-- Docker CE + Compose V2 (for sandboxes)
+- Tailscale (mesh VPN, optional)
+- Firewall rules for SSH and optional Tailscale access
+- Docker CE + Compose V2 on Debian/Ubuntu
+- rootless Podman + rootless Quadlets on Fedora/RHEL-family systems
 - Node.js 22.x + pnpm
-- OpenClaw on host (not containerized)
-- Systemd service (auto-start)
+- OpenClaw host CLI and state directories
+- Systemd environment setup for the `openclaw` user
 
 ## Post-Install
 
@@ -72,18 +89,20 @@ After installation completes, switch to the openclaw user:
 sudo su - openclaw
 ```
 
-Then run the quick-start onboarding wizard:
+On Debian/Ubuntu, run the quick-start onboarding wizard:
 
 ```bash
 openclaw onboard --install-daemon
 ```
 
-This will:
-- Guide you through the setup wizard
-- Configure your messaging provider (WhatsApp/Telegram/Signal)
-- Install and start the daemon service
+On Fedora/RHEL-family systems, the playbook installs a rootless Quadlet service. Manage it as the `openclaw` user:
 
-After onboarding, run the [post-install security verification](docs/security.md#verification). The checks confirm that the firewall and SSH protection are active, Docker-published ports remain externally blocked, and OpenClaw only listens on localhost.
+```bash
+systemctl --user status openclaw.service
+journalctl --user -u openclaw.service -f
+```
+
+After onboarding, run the [post-install security verification](docs/security.md#verification). The checks confirm that the firewall and SSH protection are active, published container ports remain localhost-only or externally blocked, and OpenClaw does not listen publicly.
 
 ### Alternative Manual Setup
 
@@ -97,7 +116,7 @@ openclaw providers login
 # Test gateway
 openclaw gateway
 
-# Install as daemon
+# Install as daemon on Debian/Ubuntu if not using onboard
 openclaw daemon install
 openclaw daemon start
 
@@ -110,18 +129,24 @@ openclaw logs
 
 ### Release Mode (Default)
 
-```bash
-# Install dependencies
-sudo apt update && sudo apt install -y ansible git
+Debian/Ubuntu:
 
-# Clone repository
+```bash
+sudo apt update && sudo apt install -y ansible git
+```
+
+Fedora/RHEL-family:
+
+```bash
+sudo dnf install -y ansible git
+```
+
+Then run:
+
+```bash
 git clone https://github.com/openclaw/openclaw-ansible.git
 cd openclaw-ansible
-
-# Install Ansible collections
 ansible-galaxy collection install -r requirements.yml
-
-# Run installation
 ./run-playbook.sh
 ```
 
@@ -130,11 +155,7 @@ ansible-galaxy collection install -r requirements.yml
 Build from source for development:
 
 ```bash
-# Same as above, but with development mode flag
 ./run-playbook.sh -e openclaw_install_mode=development
-
-# Or directly:
-ansible-playbook playbook.yml --ask-become-pass -e openclaw_install_mode=development
 ```
 
 This will:
@@ -243,15 +264,36 @@ Alternatively, to run the playbook from your existing project setup, run the pla
 
 Enable with: `-e openclaw_install_mode=development`
 
+## RedHat-family operations
+
+Run these as the `openclaw` user unless noted:
+
+```bash
+loginctl show-user openclaw
+systemctl --user status openclaw.service
+journalctl --user -u openclaw.service -f
+podman ps
+```
+
+Quadlet files live in:
+
+```text
+/home/openclaw/.config/containers/systemd/openclaw.container
+```
+
+The playbook configures `/etc/subuid`, `/etc/subgid`, and `loginctl enable-linger openclaw` so the rootless user service can persist after reboot.
+
 ## Security
 
 - **Public ports**: SSH (22), Tailscale (41641/udp) only
-- **Fail2ban**: SSH brute-force protection (5 attempts → 1 hour ban)
-- **Automatic updates**: Security patches via unattended-upgrades
-- **Docker isolation**: Containers can't expose ports externally (DOCKER-USER chain)
+- **Fail2ban**: SSH brute-force protection on Debian/Ubuntu
+- **Automatic updates**: Security patches via unattended-upgrades on Debian/Ubuntu
+- **Docker isolation**: Debian/Ubuntu Docker publishes are blocked externally through DOCKER-USER
+- **Rootless Podman**: Fedora/RHEL-family installs never use rootful Podman
 - **Non-root**: OpenClaw runs as unprivileged user
 - **Scoped sudo**: Limited to service management (not full root)
-- **Systemd hardening**: NoNewPrivileges, PrivateTmp, ProtectSystem
+- **Systemd hardening**: NoNewPrivileges, PrivateTmp, ProtectSystem where OpenClaw installs a host daemon
+- **SELinux**: RedHat-family installs keep SELinux enabled and use `:Z` labels for container bind mounts
 
 Run the [post-install security verification](docs/security.md#verification) for commands and expected results. In the default configuration, an external TCP scan should show only SSH on port 22; Tailscale uses UDP and is not included in that TCP scan.
 
@@ -260,109 +302,23 @@ Run the [post-install security verification](docs/security.md#verification) for 
 For high-security environments, audit before running:
 
 ```bash
-git clone https://github.com/openclaw/openclaw-ansible.git
-cd openclaw-ansible
-# Review playbook.yml and roles/
-ansible-playbook playbook.yml --check --diff  # Dry run
-ansible-playbook playbook.yml --ask-become-pass
+curl -fsSL https://raw.githubusercontent.com/openclaw/openclaw-ansible/main/install.sh -o install.sh
+less install.sh
+bash install.sh
 ```
+
+## Configuration
+
+See [docs/configuration.md](docs/configuration.md) for all available variables and customization options.
 
 ## Documentation
 
-- [Configuration Guide](docs/configuration.md) - All configuration options
-- [Development Mode](docs/development-mode.md) - Build from source
-- [Security Architecture](docs/security.md) - Security details
-- [Technical Details](docs/architecture.md) - Architecture overview
-- [Troubleshooting](docs/troubleshooting.md) - Common issues
-- [Agent Guidelines](AGENTS.md) - AI agent instructions
-
-## Requirements
-
-- Debian 11+ or Ubuntu 20.04+
-- Root/sudo access
-- Internet connection
-
-## Configuration Options
-
-All configuration variables can be found in [`roles/openclaw/defaults/main.yml`](roles/openclaw/defaults/main.yml).
-
-You can override them in three ways:
-
-### 1. Via Command Line
-
-```bash
-ansible-playbook playbook.yml --ask-become-pass \
-  -e openclaw_install_mode=development \
-  -e "openclaw_ssh_keys=['ssh-ed25519 AAAAC3... user@host']"
-```
-
-### 2. Via Variables File
-
-```bash
-# Create vars.yml
-cat > vars.yml << EOF
-openclaw_install_mode: development
-openclaw_ssh_keys:
-  - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIGxxxxxxxx user@host"
-  - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAAB... user@host"
-openclaw_repo_url: "https://github.com/YOUR_USERNAME/openclaw.git"
-openclaw_repo_branch: "feature-branch"
-tailscale_authkey: "tskey-auth-xxxxxxxxxxxxx"
-EOF
-
-# Use it
-ansible-playbook playbook.yml --ask-become-pass -e @vars.yml
-```
-
-### 3. Edit Defaults Directly
-
-Edit `roles/openclaw/defaults/main.yml` before running the playbook.
-
-### Available Variables
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `openclaw_user` | `openclaw` | System user name |
-| `openclaw_home` | `/home/openclaw` | User home directory |
-| `openclaw_install_mode` | `release` | `release` or `development` |
-| `openclaw_ssh_keys` | `[]` | List of SSH public keys |
-| `openclaw_repo_url` | `https://github.com/openclaw/openclaw.git` | Git repository (dev mode) |
-| `openclaw_repo_branch` | `main` | Git branch (dev mode) |
-| `tailscale_authkey` | `""` | Tailscale auth key for auto-connect |
-| `nodejs_version` | `22.x` | Node.js version to install |
-
-See [`roles/openclaw/defaults/main.yml`](roles/openclaw/defaults/main.yml) for the complete list.
-
-### Common Configuration Examples
-
-#### SSH Keys for Remote Access
-
-```bash
-ansible-playbook playbook.yml --ask-become-pass \
-  -e "openclaw_ssh_keys=['ssh-ed25519 AAAAC3... user@host']"
-```
-
-#### Development Mode with Custom Repository
-
-```bash
-ansible-playbook playbook.yml --ask-become-pass \
-  -e openclaw_install_mode=development \
-  -e openclaw_repo_url=https://github.com/YOUR_USERNAME/openclaw.git \
-  -e openclaw_repo_branch=feature-branch
-```
-
-#### Tailscale Auto-Connect
-
-```bash
-ansible-playbook playbook.yml --ask-become-pass \
-  -e tailscale_authkey=tskey-auth-xxxxxxxxxxxxx
-```
-
-## License
-
-MIT - see [LICENSE](LICENSE)
+- [Installation Guide](docs/installation.md)
+- [Security Architecture](docs/security.md)
+- [Configuration Reference](docs/configuration.md)
+- [Troubleshooting](docs/troubleshooting.md)
 
 ## Support
 
-- OpenClaw: https://github.com/openclaw/openclaw
-- This installer: https://github.com/openclaw/openclaw-ansible/issues
+- OpenClaw issues: https://github.com/openclaw/openclaw/issues
+- Installer issues: https://github.com/openclaw/openclaw-ansible/issues

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,132 +1,98 @@
 ---
 title: Architecture
-description: Technical implementation details
+description: OpenClaw Ansible installer task flow and platform-specific runtime architecture
 ---
 
 # Architecture
 
-## Component Overview
+The installer keeps one common OpenClaw setup flow and splits OS-native security/runtime tasks by OS family.
 
-```
-┌─────────────────────────────────────────┐
-│ UFW Firewall (SSH only)                 │
-└──────────────┬──────────────────────────┘
-               │
-┌──────────────┴──────────────────────────┐
-│ DOCKER-USER Chain (iptables)            │
-│ Blocks all external container access    │
-└──────────────┬──────────────────────────┘
-               │
-┌──────────────┴──────────────────────────┐
-│ Docker Daemon                            │
-│ - Non-root containers                    │
-│ - Localhost-only binding                 │
-└──────────────┬──────────────────────────┘
-               │
-┌──────────────┴──────────────────────────┐
-│ OpenClaw Container                       │
-│ User: openclaw                           │
-│ Port: 127.0.0.1:3000                     │
-└──────────────────────────────────────────┘
+## Platform matrix
+
+| Platform | Firewall | Container runtime | Service model |
+| --- | --- | --- | --- |
+| Debian/Ubuntu | UFW | Docker CE + Compose V2 | Host OpenClaw daemon installed during onboarding |
+| Fedora/RHEL family | firewalld | rootless Podman only | Rootless Podman Quadlet under the `openclaw` user |
+
+RedHat-family support requires Fedora 38+ or RHEL-family 9+. CentOS 7 and RHEL-family 7/8 are rejected because rootless Podman Quadlets are required.
+
+## Task flow
+
+```text
+preflight.yml          # load OS vars, reject unsupported/rootful modes
+system-tools.yml       # Debian apt tools or RedHat dnf tools
+tailscale-*.yml        # optional Tailscale repo/package/service
+user.yml               # create non-root openclaw user and user-systemd env
+runtime setup          # Docker on Debian; rootless Podman user prep on RedHat
+firewall setup         # UFW on Debian; firewalld on RedHat
+nodejs.yml             # NodeSource packages for the OS family
+openclaw.yml           # pnpm install and OpenClaw directories
+quadlet-redhat.yml     # RedHat only: rootless Quadlet generation/start
 ```
 
-## File Structure
+## Debian and Ubuntu path
 
-```
-/opt/openclaw/
-├── Dockerfile
-├── docker-compose.yml
+Debian-family hosts preserve the existing behavior:
+
+1. Install Docker CE and Compose V2 from Docker's apt repository.
+2. Add the `openclaw` user to the `docker` group.
+3. Configure UFW default deny policies.
+4. Add a DOCKER-USER chain to block externally forwarded Docker traffic.
+5. Configure `/etc/docker/daemon.json` and restart Docker when it changes.
+6. Install OpenClaw with pnpm; onboarding installs the host daemon.
+
+Docker is installed for sandbox/container workflows. The gateway setup still runs through OpenClaw onboarding unless the operator chooses a different flow.
+
+## Fedora and RHEL-family path
+
+RedHat-family hosts use native packages and rootless Podman only:
+
+1. Install Podman, rootless networking/storage helpers, firewalld, SELinux support, Node.js, and system tools with `dnf`.
+2. Create the non-root `openclaw` user.
+3. Ensure `/etc/subuid` and `/etc/subgid` ranges for the app user.
+4. Enable linger with `loginctl enable-linger openclaw`.
+5. Start the `user@<uid>.service` user manager.
+6. Verify `podman info` reports rootless mode as the app user.
+7. Configure firewalld permanent/immediate rules for SSH and optional Tailscale.
+8. Generate `/home/openclaw/.config/containers/systemd/openclaw.container`.
+9. Run `systemctl --user daemon-reload` and `systemctl --user enable --now openclaw.service` as the app user.
+
+The RedHat path never starts rootful Podman services, never writes OpenClaw Quadlets to system Quadlet directories, and never falls back to Docker.
+
+## Rootless Quadlet layout
+
+```text
+/home/openclaw/.config/containers/systemd/
+└── openclaw.container
 
 /home/openclaw/.openclaw/
-├── config.yml
-├── sessions/
-└── credentials/
-
-/etc/systemd/system/
-└── openclaw.service
-
-/etc/docker/
-└── daemon.json
-
-/etc/ufw/
-└── after.rules (DOCKER-USER chain)
+├── .env
+├── openclaw.json
+└── workspace/
 ```
 
-## Service Management
+The Quadlet publishes localhost ports only:
 
-OpenClaw runs as a systemd service that manages the Docker container:
-
-```bash
-# Systemd controls Docker Compose
-systemd → docker compose → openclaw container
+```text
+127.0.0.1:18789:18789
+127.0.0.1:18790:18790
 ```
 
-## Installation Flow
+Bind mounts use SELinux private labels with `:Z`.
 
-1. **Tailscale Setup** (`tailscale.yml`)
-   - Add Tailscale repository
-   - Install Tailscale package
-   - Display connection instructions
+## Security boundaries
 
-2. **User Creation** (`user.yml`)
-   - Create `openclaw` system user
+- Firewall rules expose SSH and optional Tailscale only.
+- OpenClaw runs as an unprivileged `openclaw` user.
+- Debian/Ubuntu uses UFW plus DOCKER-USER to prevent accidental Docker exposure.
+- Fedora/RHEL-family uses rootless Podman and user-scoped systemd only.
+- SELinux is not disabled.
+- Rootful Podman is explicitly unsupported.
 
-3. **Docker Installation** (`docker.yml`)
-   - Install Docker CE + Compose V2
-   - Add user to docker group
-   - Create `/etc/docker` directory
+## Ansible collections
 
-4. **Firewall Setup** (`firewall.yml`)
-   - Install UFW
-   - Configure DOCKER-USER chain
-   - Configure Docker daemon (`/etc/docker/daemon.json`)
-   - Allow SSH (22/tcp) and Tailscale (41641/udp)
+Required collections are declared in `requirements.yml`:
 
-5. **Node.js Installation** (`nodejs.yml`)
-   - Add NodeSource repository
-   - Install Node.js 22.x
-   - Install pnpm globally
-
-6. **OpenClaw Setup** (`openclaw.yml`)
-   - Create directories
-   - Generate configs from templates
-   - Build Docker image
-   - Start container via Compose
-   - Install systemd service
-
-## Key Design Decisions
-
-### Why UFW + DOCKER-USER?
-
-Docker manipulates iptables directly, bypassing UFW. The DOCKER-USER chain is evaluated before Docker's FORWARD chain, allowing us to block traffic before Docker sees it.
-
-### Why Localhost Binding?
-
-Defense in depth. Even if DOCKER-USER fails, localhost binding prevents external access.
-
-### Why Systemd Service?
-
-- Auto-start on boot
-- Clean lifecycle management
-- Integration with system logs
-- Dependency management (after Docker)
-
-### Why Non-Root Container?
-
-Principle of least privilege. If container is compromised, attacker has limited privileges.
-
-## Ansible Task Order
-
-```
-main.yml
-├── tailscale.yml (VPN setup)
-├── user.yml (create openclaw user)
-├── docker.yml (install Docker, create /etc/docker)
-├── firewall.yml (configure UFW + Docker daemon)
-├── nodejs.yml (Node.js + pnpm)
-└── openclaw.yml (container setup)
-```
-
-Order matters: Docker must be installed before firewall configuration because:
-1. `/etc/docker` directory must exist for `daemon.json`
-2. Docker service must exist to be restarted after config changes
+- `ansible.posix` for `firewalld` and authorized keys
+- `community.general` for shared utility modules
+- `community.docker` for Debian/Ubuntu Docker tasks

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -5,238 +5,212 @@ description: Detailed installation and configuration instructions
 
 # Installation Guide
 
-## Quick Install
+Use this guide to install OpenClaw on a supported Linux server with the OS-native firewall and container runtime.
+
+## Supported platforms
+
+| Platform | Version | Runtime |
+| --- | --- | --- |
+| Debian | 11+ | Docker CE + Compose V2 |
+| Ubuntu | 20.04+ | Docker CE + Compose V2 |
+| Fedora | 38+ | rootless Podman + rootless Quadlets |
+| RHEL, CentOS Stream, AlmaLinux, Rocky Linux, Oracle Linux | 9+ | rootless Podman + rootless Quadlets |
+
+CentOS 7 and RHEL-family 7/8 are unsupported.
+
+## Quick install
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/openclaw/openclaw-ansible/main/install.sh | bash
 ```
 
-## Manual Installation
+## Manual installation
 
 ### Prerequisites
+
+Debian/Ubuntu:
 
 ```bash
 sudo apt update
 sudo apt install -y ansible git
 ```
 
-### Clone and Run
+Fedora/RHEL family:
+
+```bash
+sudo dnf install -y ansible git
+```
+
+### Clone and run
 
 ```bash
 git clone https://github.com/openclaw/openclaw-ansible.git
 cd openclaw-ansible
-
-# Install Ansible collections
 ansible-galaxy collection install -r requirements.yml
-
-# Run playbook
 ansible-playbook playbook.yml --ask-become-pass
 ```
 
-## Post-Installation
+## What the playbook installs
 
-### 1. Connect to Tailscale
+Debian/Ubuntu:
+
+- UFW firewall
+- fail2ban
+- unattended-upgrades
+- Docker CE + Compose V2
+- Node.js + pnpm
+- OpenClaw host CLI and state directories
+
+Fedora/RHEL family:
+
+- firewalld
+- rootless Podman dependencies: `podman`, `slirp4netns`, `fuse-overlayfs`, `shadow-utils`
+- SELinux support packages: `container-selinux`, `policycoreutils-python-utils`, `python3-libselinux`
+- rootless user setup: `/etc/subuid`, `/etc/subgid`, and lingering
+- rootless Quadlet at `/home/openclaw/.config/containers/systemd/openclaw.container`
+- Node.js + pnpm
+- OpenClaw host CLI and state directories
+
+## Post-install setup
+
+### Debian/Ubuntu
+
+Switch to the OpenClaw user:
 
 ```bash
-# Interactive login
-sudo tailscale up
-
-# Or with auth key for automation
-sudo tailscale up --authkey tskey-auth-xxxxx
-
-# Check status
-sudo tailscale status
+sudo su - openclaw
 ```
 
-Get auth keys from: https://login.tailscale.com/admin/settings/keys
-
-### 2. Configure OpenClaw
+Run onboarding:
 
 ```bash
-# Edit config
-sudo nano /home/openclaw/.openclaw/config.yml
-
-# Key settings to configure:
-# - provider: whatsapp/telegram/signal
-# - phone: your number
-# - ai.provider: anthropic/openai
-# - ai.model: claude-3-5-sonnet-20241022
+openclaw onboard --install-daemon
 ```
 
-### 3. Login to Provider
+Then manage the daemon with the OpenClaw CLI:
 
 ```bash
-# Login (will prompt for QR code or phone verification)
-sudo docker exec -it openclaw openclaw login
-
-# Check connection
-sudo docker logs -f openclaw
+openclaw status
+openclaw logs
+openclaw daemon restart
 ```
 
-## Service Management
+### Fedora/RHEL family
 
-### Systemd Commands
+Switch to the OpenClaw user:
 
 ```bash
-# Start/stop/restart
-sudo systemctl start openclaw
-sudo systemctl stop openclaw
-sudo systemctl restart openclaw
-
-# View status
-sudo systemctl status openclaw
-
-# Enable/disable auto-start
-sudo systemctl enable openclaw
-sudo systemctl disable openclaw
+sudo su - openclaw
 ```
 
-### Docker Commands
+The playbook creates and starts the rootless Quadlet service. Check it with:
 
 ```bash
-# View logs
-sudo docker logs openclaw
-sudo docker logs -f openclaw  # follow
-
-# Shell access
-sudo docker exec -it openclaw bash
-
-# Restart container
-sudo docker restart openclaw
-
-# Check status
-sudo docker compose -f /opt/openclaw/docker-compose.yml ps
+loginctl show-user openclaw
+systemctl --user status openclaw.service
+journalctl --user -u openclaw.service -f
 ```
 
-### Firewall Management
+Provider login and configuration still run as the `openclaw` user:
 
 ```bash
-# View UFW status
+openclaw providers login
+openclaw configure
+```
+
+## Firewall management
+
+Debian/Ubuntu:
+
+```bash
 sudo ufw status verbose
-
-# Add custom rule
-sudo ufw allow 8080/tcp comment 'Custom service'
-sudo ufw reload
-
-# View Docker isolation
 sudo iptables -L DOCKER-USER -n -v
 ```
 
+Fedora/RHEL family:
+
+```bash
+sudo firewall-cmd --state
+sudo firewall-cmd --list-all
+```
+
+Only SSH and optional Tailscale should be exposed publicly by default.
+
+## Rootless Podman operations
+
+Run these as the `openclaw` user:
+
+```bash
+systemctl --user status openclaw.service
+systemctl --user restart openclaw.service
+journalctl --user -u openclaw.service -f
+podman ps
+podman logs -f openclaw
+```
+
+Quadlet location:
+
+```text
+/home/openclaw/.config/containers/systemd/openclaw.container
+```
+
+The installer never writes OpenClaw Quadlets to system Quadlet directories and never manages rootful Podman services.
+
 ## Accessing OpenClaw
 
-OpenClaw's web interface runs on port 3000 (localhost only).
-
-### Via Tailscale (Recommended)
+OpenClaw binds to localhost by default. Use an SSH tunnel from your workstation:
 
 ```bash
-# After connecting Tailscale, browse to:
-http://TAILSCALE_IP:3000
+ssh -L 3000:localhost:3000 user@gateway-host
 ```
 
-Wait, port 3000 is bound to localhost, so this won't work directly. Need to update the compose file or use SSH tunnel.
-
-### Via SSH Tunnel
-
-```bash
-ssh -L 3000:localhost:3000 user@server
-# Then browse to: http://localhost:3000
-```
+Then browse to `http://localhost:3000`.
 
 ## Verification
 
-Run the complete [post-install security verification](security.md#verification). It includes every command, the expected healthy result, and notes about output that varies by host.
+Run the complete [post-install security verification](security.md#verification). It includes every command, the expected healthy result, and notes about host-specific output.
 
 At minimum, confirm:
 
-- UFW is active with incoming and routed traffic denied by default.
-- The `sshd` fail2ban jail is enabled.
+- The firewall is active.
 - OpenClaw listens on `127.0.0.1`, not `0.0.0.0`.
-- The `DOCKER-USER` chain drops externally routed container traffic.
-- An external TCP scan exposes only the configured SSH port.
-- A published test container works locally but cannot be reached externally.
-- Tailscale is connected when enabled, and unattended upgrades are active.
+- An external TCP scan exposes only SSH.
+- Debian/Ubuntu: the `DOCKER-USER` chain drops externally routed container traffic.
+- Fedora/RHEL family: Podman reports rootless mode as the `openclaw` user.
+- Fedora/RHEL family: Quadlets are under `/home/openclaw/.config/containers/systemd/` only.
+- Tailscale is connected when enabled.
 
 ## Uninstall
 
-```bash
-# Stop services
-sudo systemctl stop openclaw
-sudo systemctl disable openclaw
-sudo tailscale down
+Debian/Ubuntu container/runtime cleanup:
 
-# Remove containers and data
-sudo docker compose -f /opt/openclaw/docker-compose.yml down
+```bash
+sudo tailscale down
 sudo rm -rf /opt/openclaw
 sudo rm -rf /home/openclaw/.openclaw
-sudo rm /etc/systemd/system/openclaw.service
-sudo systemctl daemon-reload
-
-# Remove packages (optional)
 sudo apt remove --purge tailscale docker-ce docker-ce-cli containerd.io docker-compose-plugin nodejs
-
-# Remove user (optional)
-sudo userdel -r openclaw
-
-# Reset firewall (optional)
 sudo ufw disable
 sudo ufw --force reset
 ```
 
-## Advanced Configuration
-
-### Custom Port
-
-Edit `/opt/openclaw/docker-compose.yml`:
-
-```yaml
-ports:
-  - "127.0.0.1:3001:3000"  # Change 3001 to desired port
-```
-
-Then restart:
-```bash
-sudo systemctl restart openclaw
-```
-
-### Environment Variables
-
-Add to `/opt/openclaw/docker-compose.yml`:
-
-```yaml
-environment:
-  - NODE_ENV=production
-  - ANTHROPIC_API_KEY=sk-ant-xxx
-  - DEBUG=openclaw:*
-```
-
-### Volume Mounts
-
-Add additional volumes in docker-compose.yml:
-
-```yaml
-volumes:
-  - /home/openclaw/.openclaw:/home/openclaw/.openclaw
-  - /path/to/custom:/custom
-```
-
-## Automation
-
-### Unattended Install
+Fedora/RHEL-family rootless Quadlet cleanup:
 
 ```bash
-# Set Tailscale auth key in playbook vars
-ansible-playbook playbook.yml \
-  --ask-become-pass \
-  -e "tailscale_authkey=tskey-auth-xxxxx"
+sudo su - openclaw
+systemctl --user disable --now openclaw.service
+rm -f ~/.config/containers/systemd/openclaw.container
+systemctl --user daemon-reload
+podman rm -f openclaw
+exit
+command -v tailscale >/dev/null 2>&1 && sudo tailscale down
+sudo rm -rf /home/openclaw/.openclaw
 ```
 
-### CI/CD Integration
+Remove the user only after preserving any data you need:
 
-```yaml
-# Example GitHub Actions
-- name: Deploy OpenClaw
-  run: |
-    ansible-playbook playbook.yml \
-      -e "tailscale_authkey=${{ secrets.TAILSCALE_KEY }}" \
-      --become
+```bash
+sudo loginctl disable-linger openclaw
+sudo loginctl terminate-user openclaw
+sudo rm -f /etc/sudoers.d/openclaw
+sudo userdel -r openclaw
 ```

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -111,12 +111,11 @@ systemctl --user status openclaw.service
 journalctl --user -u openclaw.service -f
 ```
 
-Provider login and configuration still run as the `openclaw` user:
-
-```bash
-openclaw providers login
-openclaw configure
-```
+On Fedora/RHEL-family installs there is no host `openclaw` binary — the gateway
+runs exclusively inside the rootless Podman container. Provider configuration
+is applied through the container environment file and `openclaw.json` written
+by the installer under `~/.openclaw/`. To interact with the running gateway,
+use its HTTP API or the OpenClaw web UI at `http://127.0.0.1:18789`.
 
 ## Firewall management
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,17 +1,26 @@
 ---
 title: Security Architecture
-description: Firewall configuration, Docker isolation, and security hardening details
+description: Firewall, container isolation, and security hardening details
 ---
 
 # Security Architecture
 
-## Overview
+This playbook uses OS-native security controls. Debian and Ubuntu keep the existing Docker + UFW model. Fedora and RHEL-family systems use firewalld and rootless Podman Quadlets only.
 
-This playbook implements a multi-layer defense strategy to secure OpenClaw installations.
+## Security layers by platform
 
-## Security Layers
+| Layer | Debian/Ubuntu | Fedora/RHEL family |
+| --- | --- | --- |
+| Firewall | UFW | firewalld |
+| SSH protection | fail2ban | firewalld baseline; add fail2ban separately if desired |
+| Security updates | unattended-upgrades | OS vendor update tooling |
+| Container runtime | Docker CE + Compose V2 | rootless Podman only |
+| Service model | OpenClaw user service/daemon | rootless Podman Quadlet under the app user |
+| SELinux | Usually not enforcing by default | Kept enabled; bind mounts use `:Z` |
 
-### Layer 1: UFW Firewall
+## Debian and Ubuntu
+
+### UFW firewall
 
 ```bash
 # Default policies
@@ -21,129 +30,112 @@ Routed: DENY
 
 # Allowed
 SSH (22/tcp): ALLOW
-Tailscale (41641/udp): ALLOW
+Tailscale (41641/udp): ALLOW when tailscale_enabled=true
 ```
 
-### Layer 2: Fail2ban (SSH Protection)
-
-Automatic protection against SSH brute-force attacks:
+### Fail2ban SSH protection
 
 ```bash
-# Configuration
-Max retries: 5 attempts
-Ban time: 1 hour (3600 seconds)
-Find time: 10 minutes (600 seconds)
-
-# Check status
 sudo fail2ban-client status sshd
-
-# Unban an IP
-sudo fail2ban-client set sshd unbanip IP_ADDRESS
 ```
 
-### Layer 3: DOCKER-USER Chain
+The default jail allows 5 failed attempts in 10 minutes and bans for 1 hour.
 
-Custom iptables chain that prevents Docker from bypassing UFW:
+### DOCKER-USER chain
 
-```
-*filter
-:DOCKER-USER - [0:0]
+The playbook adds a DOCKER-USER chain that drops externally forwarded traffic before Docker can expose it:
+
+```text
 -A DOCKER-USER -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 -A DOCKER-USER -i lo -j ACCEPT
 -A DOCKER-USER -i <default_interface> -j DROP
-COMMIT
 ```
 
-**Result**: Even `docker run -p 80:80 nginx` won't expose port 80 externally.
+Result: even `docker run -p 80:80 nginx` should not expose port 80 externally.
 
-### Layer 4: Localhost-Only Binding
+### Automatic security updates
 
-All container ports bind to 127.0.0.1:
+Unattended-upgrades installs security updates automatically. Automatic reboots are disabled.
 
-```yaml
-ports:
-  - "127.0.0.1:3000:3000"
+## Fedora and RHEL-family systems
+
+### firewalld
+
+The playbook installs, enables, and starts `firewalld`. It opens:
+
+- `22/tcp` for SSH
+- `41641/udp` for Tailscale when `tailscale_enabled=true`
+
+Rules are permanent and immediate through `ansible.posix.firewalld`.
+
+### Rootless Podman only
+
+RedHat-family installs use rootless Podman and rootless Quadlets. The playbook intentionally does not support rootful Podman.
+
+The playbook fails instead of:
+
+- enabling rootful Podman services
+- writing Quadlets to system directories
+- falling back to Docker
+- using a root app user
+
+Rootless setup includes:
+
+- `/etc/subuid` and `/etc/subgid` ranges for the `openclaw` user
+- `loginctl enable-linger openclaw`
+- app-user-owned Quadlet directory at `/home/openclaw/.config/containers/systemd/`
+- user-scoped `systemctl --user daemon-reload`
+- user-scoped `systemctl --user enable --now openclaw.service`
+
+### SELinux
+
+SELinux stays enabled. The rootless Quadlet uses private labels on bind mounts:
+
+```text
+Volume=/home/openclaw/.openclaw:/home/node/.openclaw:Z
+Volume=/home/openclaw/.openclaw/workspace:/home/node/.openclaw/workspace:Z
 ```
 
-### Layer 5: Non-Root Container
-
-Container processes run as unprivileged `openclaw` user.
-
-### Layer 6: Systemd Hardening
-
-The openclaw service runs with security restrictions:
-
-- `NoNewPrivileges=true` - Prevents privilege escalation
-- `PrivateTmp=true` - Isolated /tmp directory
-- `ProtectSystem=strict` - Read-only system directories
-- `ProtectHome=read-only` - Limited home directory access
-- `ReadWritePaths` - Only ~/.openclaw is writable
-
-### Layer 7: Scoped Sudo Access
-
-The openclaw user has limited sudo permissions (not full root):
-
-```bash
-# Allowed commands only:
-- systemctl start/stop/restart/status openclaw
-- systemctl daemon-reload
-- tailscale commands
-- journalctl for openclaw logs
-```
-
-### Layer 8: Automatic Security Updates
-
-Unattended-upgrades is configured for automatic security patches:
-
-```bash
-# Check status
-sudo unattended-upgrade --dry-run
-
-# View logs
-sudo cat /var/log/unattended-upgrades/unattended-upgrades.log
-```
-
-**Note**: Automatic reboots are disabled. Monitor for pending reboots:
-```bash
-cat /var/run/reboot-required 2>/dev/null || echo "No reboot required"
-```
+Use `:Z` for private OpenClaw container state. Do not disable SELinux to work around mount issues.
 
 ## Verification
 
-Run these checks after installation and onboarding. Interface names, IP addresses, packet counters, and process IDs vary by host; compare the stated healthy result rather than expecting byte-for-byte output.
+Run these checks after installation and onboarding. Interface names, IP addresses, counters, and process IDs vary by host; compare the stated healthy result rather than expecting byte-for-byte output.
 
 ### Firewall
+
+Debian/Ubuntu:
 
 ```bash
 sudo ufw status verbose
 ```
 
-Expected: `Status: active`, with incoming and routed traffic denied by default. The default rules allow `22/tcp` for SSH and, when Tailscale is enabled, `41641/udp`; IPv6-enabled hosts may show matching `(v6)` entries.
+Expected: `Status: active`, with incoming and routed traffic denied by default. The default rules allow `22/tcp` for SSH and, when Tailscale is enabled, `41641/udp`.
 
-### SSH Protection
+Fedora/RHEL family:
 
 ```bash
-sudo fail2ban-client status
-sudo fail2ban-client status sshd
+sudo firewall-cmd --state
+sudo firewall-cmd --list-all
 ```
 
-Expected: the first command lists `sshd` under `Jail list`; the second reports the jail as active and shows its failure and ban counters. Zero failures or bans is healthy.
+Expected: firewalld is running. The active zone allows SSH and, when Tailscale is enabled, `41641/udp`.
 
-### Local Listeners
+### Local listeners
 
 ```bash
 sudo ss -tlnp
 ```
 
-Expected: SSH listens on the configured public address or `0.0.0.0`; OpenClaw and its supporting services listen on `127.0.0.1`. No OpenClaw or Docker service should listen on `0.0.0.0`.
+Expected: SSH listens on the configured public address or `0.0.0.0`; OpenClaw and supporting services listen on `127.0.0.1`. No OpenClaw service should listen on `0.0.0.0`.
 
-### Docker Isolation
+### Debian/Ubuntu Docker isolation
 
 ```bash
 sudo iptables -L DOCKER-USER -n -v
 ```
 
-Expected: the chain includes accepts for established traffic and loopback traffic, followed by a drop rule for traffic arriving on the server's default external interface. Packet counters may be zero before traffic reaches the chain.
+Expected: the chain accepts established and loopback traffic, then drops traffic arriving on the server's default external interface.
 
 From another machine, scan the server:
 
@@ -151,7 +143,7 @@ From another machine, scan the server:
 nmap -p- YOUR_SERVER_IP
 ```
 
-Expected: only the configured SSH TCP port is open in the default configuration. Tailscale uses UDP port `41641`, so it does not appear in this TCP scan.
+Expected: only the configured SSH TCP port is open in the default configuration.
 
 Then publish a temporary container port:
 
@@ -162,7 +154,32 @@ curl --fail http://localhost:80
 sudo docker rm -f test-nginx
 ```
 
-Expected: the external request fails or times out, while the localhost request returns the nginx welcome page. Remove the test container even if either request produces an unexpected result.
+Expected: the external request fails or times out, while the localhost request returns the nginx welcome page.
+
+### Fedora/RHEL rootless Podman
+
+Run these as the `openclaw` user:
+
+```bash
+loginctl show-user openclaw
+systemctl --user status openclaw.service
+journalctl --user -u openclaw.service -n 100
+podman info --format '{{.Host.Security.Rootless}}'
+podman ps
+```
+
+Expected:
+
+- `Linger=yes` for `openclaw`
+- `openclaw.service` exists under the user systemd manager
+- Podman reports `true` for rootless mode
+- Quadlet file exists at `/home/openclaw/.config/containers/systemd/openclaw.container`
+
+Also confirm no rootful Quadlet path is used:
+
+```bash
+test ! -e /etc/containers/systemd/openclaw.container
+```
 
 ### Tailscale
 
@@ -172,69 +189,52 @@ sudo tailscale status
 
 When Tailscale is enabled, expected: the server has a `100.x.x.x` Tailscale address and appears in the peer table. `Logged out` or `Stopped` means `sudo tailscale up` still needs to be completed. Skip this check when `tailscale_enabled` is false.
 
-### Automatic Security Updates
+## Tailscale access
+
+OpenClaw binds to localhost by default. Access it with an SSH tunnel unless you intentionally configure another private access path:
 
 ```bash
-sudo systemctl status unattended-upgrades
+ssh -L 3000:localhost:3000 user@gateway-host
 ```
 
-Expected: the unit is loaded and active. Use `sudo unattended-upgrade --dry-run --debug` if the service is inactive or reports errors.
+Then browse to `http://localhost:3000` from your workstation.
 
-## Tailscale Access
+## Known limitations
 
-OpenClaw's web interface (port 3000) is bound to localhost. Access it via:
+### Unsupported RedHat-family versions
 
-1. **SSH tunnel**:
-   ```bash
-   ssh -L 3000:localhost:3000 user@server
-   # Then browse to http://localhost:3000
-   ```
+CentOS 7 and RHEL-family 7/8 are unsupported because the installer requires rootless Podman Quadlets. Use Fedora 38+ or a RHEL-family 9+ host.
 
-2. **Tailscale** (recommended):
-   ```bash
-   # On server: already done by playbook
-   sudo tailscale up
-   
-   # From your machine:
-   # Browse to http://TAILSCALE_IP:3000
-   ```
+### Rootful Podman
 
-## Network Flow
-
-```
-Internet → UFW (SSH only) → fail2ban → DOCKER-USER Chain → DROP
-Container → NAT → Internet (outbound allowed)
-```
-
-## Known Limitations
-
-### macOS Support
-- macOS firewall configuration is basic (Application Firewall only)
-- No fail2ban equivalent on macOS
-- Consider using Little Snitch or similar for enhanced macOS security
+Rootful Podman is not supported and will not be added as a fallback. If rootless Podman cannot start, fix the rootless user, subuid/subgid, lingering, or systemd user manager state.
 
 ### IPv6
-- Docker IPv6 is disabled by default (`ip6tables: false` in daemon.json)
-- If your network uses IPv6, review and test firewall rules accordingly
 
-### Installation Script
-- The `curl | bash` installation pattern has inherent risks
-- For high-security environments, clone the repository and audit before running
-- Consider using `--check` mode first: `ansible-playbook playbook.yml --check`
+Docker IPv6 is disabled by default on Debian/Ubuntu (`ip6tables: false` in `daemon.json`). If your network uses IPv6, review and test firewall rules accordingly.
 
-## Security Checklist
+### Installation script
+
+The `curl | bash` installation pattern has inherent risks. For high-security environments, clone the repository and audit before running. Consider `ansible-playbook playbook.yml --check` first.
+
+## Security checklist
 
 After installation, verify:
 
-- [ ] `sudo ufw status` shows only SSH and Tailscale allowed
-- [ ] `sudo fail2ban-client status sshd` shows jail active
-- [ ] `sudo iptables -L DOCKER-USER -n` shows DROP rule
-- [ ] `nmap -p- YOUR_IP` from external shows only port 22
-- [ ] `docker run -p 80:80 nginx` + `curl YOUR_IP:80` times out
-- [ ] Tailscale access works for web UI
+- [ ] Only SSH and optional Tailscale are exposed publicly
+- [ ] Debian/Ubuntu: `sudo ufw status` is active
+- [ ] Debian/Ubuntu: `sudo fail2ban-client status sshd` shows the jail active
+- [ ] Debian/Ubuntu: `sudo iptables -L DOCKER-USER -n` shows the drop rule
+- [ ] Fedora/RHEL family: `sudo firewall-cmd --state` reports `running`
+- [ ] Fedora/RHEL family: `podman info` as `openclaw` reports rootless mode
+- [ ] Fedora/RHEL family: Quadlet file is under `/home/openclaw/.config/containers/systemd/`
+- [ ] Fedora/RHEL family: no OpenClaw Quadlet exists under a system Quadlet directory
+- [ ] External TCP scan shows only the configured SSH port
+- [ ] Tailscale access works when enabled
 
-## Reporting Security Issues
+## Reporting security issues
 
 If you discover a security vulnerability, please report it privately:
+
 - OpenClaw: https://github.com/openclaw/openclaw/security
 - This installer: https://github.com/openclaw/openclaw-ansible/security

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,160 +1,123 @@
 ---
 title: Troubleshooting
-description: Common issues and solutions
+description: Common OpenClaw Ansible installer failures and checks
 ---
 
 # Troubleshooting
 
-## Container Can't Reach Internet
+Start with the platform-specific checks below. Replace `openclaw` with your configured app user if you changed `openclaw_user`.
 
-**Symptom**: OpenClaw can't connect to WhatsApp/Telegram
+## Firewall blocks access
 
-**Check**:
+Only SSH and optional Tailscale are exposed publicly by default. Use an SSH tunnel for the local gateway port:
+
 ```bash
-# Test from container
-sudo docker exec openclaw ping -c 3 8.8.8.8
-
-# Check UFW allows outbound
-sudo ufw status verbose | grep OUT
+ssh -L 3000:localhost:3000 user@gateway-host
 ```
 
-**Solution**:
+Debian/Ubuntu firewall checks:
+
 ```bash
-# Verify DOCKER-USER allows established connections
-sudo iptables -L DOCKER-USER -n -v
-
-# Restart Docker + Firewall
-sudo systemctl restart docker
-sudo ufw reload
-sudo systemctl restart openclaw
-```
-
-## Port Already in Use
-
-**Symptom**: Port 3000 conflict
-
-**Solution**:
-```bash
-# Find what's using port 3000
-sudo ss -tlnp | grep 3000
-
-# Change OpenClaw port
-sudo nano /opt/openclaw/docker-compose.yml
-# Change: "127.0.0.1:3001:3000"
-
-sudo systemctl restart openclaw
-```
-
-## Firewall Lockout
-
-**Symptom**: Can't SSH after installation
-
-**Solution** (via console/rescue mode):
-```bash
-# Disable UFW temporarily
-sudo ufw disable
-
-# Check SSH rule exists
-sudo ufw status numbered
-
-# Re-add SSH rule
-sudo ufw allow 22/tcp
-
-# Re-enable
-sudo ufw enable
-```
-
-## Container Won't Start
-
-**Check logs**:
-```bash
-# Systemd logs
-sudo journalctl -u openclaw -n 50
-
-# Docker logs
-sudo docker logs openclaw
-
-# Compose status
-sudo docker compose -f /opt/openclaw/docker-compose.yml ps
-```
-
-**Common fixes**:
-```bash
-# Rebuild image
-cd /opt/openclaw
-sudo docker compose build --no-cache
-sudo systemctl restart openclaw
-
-# Check permissions
-sudo chown -R openclaw:openclaw /home/openclaw/.openclaw
-```
-
-## Verify Docker Isolation
-
-**Test that external ports are blocked**:
-```bash
-# Start test container
-sudo docker run -d -p 80:80 --name test-nginx nginx
-
-# From EXTERNAL machine (should fail):
-curl http://YOUR_SERVER_IP:80
-
-# From SERVER (should work):
-curl http://localhost:80
-
-# Cleanup
-sudo docker rm -f test-nginx
-```
-
-## UFW Status Shows Inactive
-
-**Fix**:
-```bash
-# Enable UFW
-sudo ufw enable
-
-# Reload rules
-sudo ufw reload
-
-# Verify
 sudo ufw status verbose
-```
-## Ansible Playbook Fails
-
-### Failed to set permissions on temporary files (Become Issue)
-
-**Symptom**: `fatal: [host]: FAILED! => {"msg": "Failed to set permissions on the temporary files Ansible needs to create when becoming an unprivileged user..."}`
-
-**Cause**: This happens when connecting as an unprivileged user (e.g., `ansible`) and using `become_user` to switch to another unprivileged user (e.g., `openclaw`). Ansible struggles to share temporary module files between them if the filesystem doesn't support POSIX ACLs.
-
-**Solution**:
-Enable **Ansible Pipelining** in your `ansible.cfg`. This executes modules via stdin without creating temporary files.
-
-```ini
-[defaults]
-pipelining = True
+sudo iptables -L DOCKER-USER -n -v
 ```
 
-Alternatively, if you cannot use pipelining, you can allow world-readable temporary files (less secure):
-```ini
-[defaults]
-allow_world_readable_tmpfiles = True
+Fedora/RHEL-family firewall checks:
+
+```bash
+sudo firewall-cmd --state
+sudo firewall-cmd --list-all
 ```
 
-### Collection missing
-...
+Expected: SSH is allowed. Tailscale UDP `41641` is allowed only when `tailscale_enabled=true`.
+
+## RedHat-family Quadlet does not start
+
+Run these as the `openclaw` user:
+
+```bash
+loginctl show-user openclaw
+systemctl --user daemon-reload
+systemctl --user status openclaw.service
+journalctl --user -u openclaw.service -n 100
+podman info --format '{{.Host.Security.Rootless}}'
+```
+
+Expected:
+
+- `Linger=yes`
+- `podman info` prints `true`
+- the Quadlet exists at `/home/openclaw/.config/containers/systemd/openclaw.container`
+
+If rootless Podman cannot start, fix the rootless setup. Do not switch to rootful Podman; the installer intentionally has no rootful fallback.
+
+## RedHat-family unsupported version failure
+
+The installer rejects CentOS 7 and RHEL-family 7/8 because rootless Quadlets require newer Podman support. Use Fedora 38+ or a RHEL-family 9+ host.
+
+## SELinux blocks Podman bind mounts
+
+Do not disable SELinux. The generated Quadlet uses `:Z` labels for private OpenClaw state. Check AVC denials with your normal SELinux tooling, then verify the bind-mounted paths are owned by the `openclaw` user:
+
+```bash
+sudo ls -ld /home/openclaw/.openclaw /home/openclaw/.openclaw/workspace
+```
+
+## Debian/Ubuntu Docker sandbox issues
+
+```bash
+sudo systemctl status docker
+sudo docker images | grep openclaw-sandbox
+sudo iptables -L DOCKER-USER -n -v
+```
+
+Build the sandbox image from a source checkout when needed:
+
+```bash
+cd /opt/openclaw/openclaw
+sudo -u openclaw ./scripts/sandbox-setup.sh
+```
+
+For npm installs without a source checkout, see the OpenClaw sandboxing documentation.
+
+## Tailscale is installed but disconnected
+
+```bash
+sudo tailscale status
+sudo tailscale up
+```
+
+For unattended setup, pass a Tailscale auth key through the documented Ansible variable and keep it out of logs and shell history.
+
+## Node.js or pnpm missing
+
+Check the installed versions:
+
+```bash
+node --version
+pnpm --version
+```
+
+Re-run the playbook after fixing repository or package-manager errors:
+
+```bash
+./run-playbook.sh
+```
+
+## Ansible collection errors
+
+Install required collections before running playbooks directly:
+
 ```bash
 ansible-galaxy collection install -r requirements.yml
 ```
 
-**Permission denied**:
+## Verification
+
+Run the security verification checklist after any fix:
+
 ```bash
-# Run with --ask-become-pass
-ansible-playbook playbook.yml --ask-become-pass
+ansible-playbook tests/verify-redhat-static.yml
 ```
 
-**Docker daemon not running**:
-```bash
-sudo systemctl start docker
-# Re-run playbook
-```
+For full host checks, follow `docs/security.md#verification`.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -7,7 +7,7 @@ readme: README.md
 authors:
   - OpenClaw Contributors <https://github.com/openclaw>
 
-description: Automated, hardened installation of OpenClaw with Docker and Tailscale VPN support for Debian/Ubuntu Linux.
+description: Automated, hardened OpenClaw installation with OS-native firewall and container runtime support.
 
 license:
   - MIT
@@ -16,15 +16,13 @@ license_file: LICENSE
 
 tags:
   - openclaw
+  - linux
   - docker
-  - tailscale
-  - vpn
+  - podman
+  - firewalld
+  - ufw
   - firewall
-  - security
-  - automation
-  - debian
-  - ubuntu
-  - messaging
+  - tailscale
 
 dependencies:
   community.docker: ">=3.4.0"
@@ -32,21 +30,4 @@ dependencies:
   ansible.posix: ">=1.5.0"
 
 repository: https://github.com/openclaw/openclaw-ansible
-documentation: https://github.com/openclaw/openclaw-ansible/blob/main/README.md
-homepage: https://github.com/openclaw/openclaw
 issues: https://github.com/openclaw/openclaw-ansible/issues
-
-build_ignore:
-  - .git
-  - .gitignore
-  - .github
-  - tests
-  - '*.tar.gz'
-  - install.sh
-  - run-playbook.sh
-  - CHANGELOG.md
-  - AGENTS.md
-  - GIT_COMMIT_MESSAGE.txt
-  - RELEASE_NOTES_v2.0.0.md
-  - UPGRADE_NOTES.md
-  - COLLECTION_MIGRATION_PLAN.md

--- a/install.sh
+++ b/install.sh
@@ -25,11 +25,19 @@ echo -e "${GREEN}╚════════════════════
 echo ""
 
 # Detect operating system
+PKG_INSTALL=""
 if command -v apt-get &> /dev/null; then
     echo -e "${GREEN}✓ Detected: Debian/Ubuntu Linux${NC}"
+    PKG_INSTALL="apt"
+elif command -v dnf &> /dev/null; then
+    echo -e "${GREEN}✓ Detected: Fedora/RHEL-family Linux${NC}"
+    PKG_INSTALL="dnf"
+elif command -v yum &> /dev/null; then
+    echo -e "${GREEN}✓ Detected: RHEL-family Linux${NC}"
+    PKG_INSTALL="yum"
 else
     echo -e "${RED}✗ Error: Unsupported operating system${NC}"
-    echo -e "${RED}  This installer supports: Debian/Ubuntu Linux only${NC}"
+    echo -e "${RED}  This installer supports: Debian/Ubuntu, Fedora, and RHEL-family Linux${NC}"
     exit 1
 fi
 
@@ -52,15 +60,23 @@ echo -e "${GREEN}[1/3] Checking prerequisites...${NC}"
 # Check if Ansible is installed
 if ! command -v ansible-playbook &> /dev/null; then
     echo -e "${YELLOW}Ansible not found. Installing Ansible and git...${NC}"
-    $SUDO apt-get update -qq
-    $SUDO apt-get install -y ansible git
+    if [ "$PKG_INSTALL" = "apt" ]; then
+        $SUDO apt-get update -qq
+        $SUDO apt-get install -y ansible git
+    else
+        $SUDO $PKG_INSTALL install -y ansible git
+    fi
     echo -e "${GREEN}✓ Ansible and git installed${NC}"
 else
     echo -e "${GREEN}✓ Ansible already installed${NC}"
     if ! command -v git &> /dev/null; then
         echo -e "${YELLOW}git not found. Installing...${NC}"
-        $SUDO apt-get update -qq
-        $SUDO apt-get install -y git
+        if [ "$PKG_INSTALL" = "apt" ]; then
+            $SUDO apt-get update -qq
+            $SUDO apt-get install -y git
+        else
+            $SUDO $PKG_INSTALL install -y git
+        fi
         echo -e "${GREEN}✓ git installed${NC}"
     else
         echo -e "${GREEN}✓ git already installed${NC}"

--- a/install.sh
+++ b/install.sh
@@ -64,7 +64,7 @@ if ! command -v ansible-playbook &> /dev/null; then
         $SUDO apt-get update -qq
         $SUDO apt-get install -y ansible git
     else
-        $SUDO $PKG_INSTALL install -y ansible git
+        $SUDO $PKG_INSTALL install -y ansible-core git
     fi
     echo -e "${GREEN}✓ Ansible and git installed${NC}"
 else

--- a/playbooks/deploy.yml
+++ b/playbooks/deploy.yml
@@ -11,7 +11,8 @@
       ansible.builtin.set_fact:
         is_linux: "{{ ansible_system == 'Linux' }}"
         is_debian_family: "{{ ansible_os_family == 'Debian' }}"
-        is_supported_distro: "{{ ansible_distribution in ['Debian', 'Ubuntu'] }}"
+        is_redhat_family: "{{ ansible_os_family == 'RedHat' }}"
+        is_supported_distro: "{{ ansible_distribution in ['Debian', 'Ubuntu'] or ansible_os_family == 'RedHat' }}"
 
     - name: Fail on unsupported non-Linux systems
       ansible.builtin.fail:
@@ -24,7 +25,8 @@
       ansible.builtin.fail:
         msg: >-
           Unsupported Linux distribution: {{ ansible_distribution }} {{ ansible_distribution_version }}.
-          This installer currently supports Debian and Ubuntu.
+          This installer supports Debian 11+, Ubuntu 20.04+, Fedora 38+, and
+          RHEL-family 9+ distributions with rootless Podman Quadlet support.
       when:
         - is_linux
         - not is_supported_distro

--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -20,7 +20,8 @@
       ansible.builtin.set_fact:
         is_linux: "{{ ansible_system == 'Linux' }}"
         is_debian_family: "{{ ansible_os_family == 'Debian' }}"
-        is_supported_distro: "{{ ansible_distribution in ['Debian', 'Ubuntu'] }}"
+        is_redhat_family: "{{ ansible_os_family == 'RedHat' }}"
+        is_supported_distro: "{{ ansible_distribution in ['Debian', 'Ubuntu'] or ansible_os_family == 'RedHat' }}"
 
     - name: Fail on unsupported non-Linux systems
       ansible.builtin.fail:
@@ -41,7 +42,8 @@
       ansible.builtin.fail:
         msg: >-
           Unsupported Linux distribution: {{ ansible_distribution }} {{ ansible_distribution_version }}.
-          This installer currently supports Debian and Ubuntu.
+          This installer supports Debian 11+, Ubuntu 20.04+, Fedora 38+, and
+          RHEL-family 9+ distributions with rootless Podman Quadlet support.
       when:
         - is_linux
         - not is_supported_distro
@@ -53,6 +55,7 @@
           OS Family: {{ ansible_os_family }}
           Linux: {{ is_linux }}
           Debian family: {{ is_debian_family }}
+          RedHat family: {{ is_redhat_family }}
           Supported distro: {{ is_supported_distro }}
 
     - name: Update apt cache and upgrade all packages (Debian/Ubuntu)

--- a/roles/openclaw/tasks/firewall-redhat.yml
+++ b/roles/openclaw/tasks/firewall-redhat.yml
@@ -1,0 +1,30 @@
+---
+# RedHat-family firewall configuration with firewalld.
+
+- name: Ensure firewalld is installed
+  ansible.builtin.dnf:
+    name: firewalld
+    state: present
+
+- name: Enable and start firewalld
+  ansible.builtin.systemd:
+    name: firewalld
+    state: started
+    enabled: true
+
+- name: Allow SSH through firewalld
+  ansible.posix.firewalld:
+    zone: "{{ openclaw_firewalld_zone }}"
+    port: 22/tcp
+    permanent: true
+    immediate: true
+    state: enabled
+
+- name: Allow Tailscale UDP through firewalld
+  ansible.posix.firewalld:
+    zone: "{{ openclaw_firewalld_zone }}"
+    port: 41641/udp
+    permanent: true
+    immediate: true
+    state: enabled
+  when: tailscale_enabled | bool

--- a/roles/openclaw/tasks/main.yml
+++ b/roles/openclaw/tasks/main.yml
@@ -1,24 +1,43 @@
 ---
+- name: Include platform preflight tasks
+  ansible.builtin.include_tasks: preflight.yml
+
 - name: Include system tools installation tasks
   ansible.builtin.include_tasks: system-tools.yml
 
-- name: Include Tailscale installation tasks
+- name: Include Tailscale installation tasks (Debian family)
   ansible.builtin.include_tasks: tailscale-linux.yml
-  when: tailscale_enabled | bool
+  when: tailscale_enabled | bool and ansible_os_family == 'Debian'
+
+- name: Include Tailscale installation tasks (RedHat family)
+  ansible.builtin.include_tasks: tailscale-redhat.yml
+  when: tailscale_enabled | bool and ansible_os_family == 'RedHat'
 
 - name: Include user creation tasks
   ansible.builtin.include_tasks: user.yml
 
-- name: Include Docker installation tasks
+- name: Include Docker installation tasks (Debian family)
   ansible.builtin.include_tasks: docker-linux.yml
-  when: not ci_test
+  when: not ci_test and openclaw_container_runtime == 'docker'
 
-- name: Include firewall configuration tasks
+- name: Include rootless Podman setup tasks (RedHat family)
+  ansible.builtin.include_tasks: podman-redhat.yml
+  when: not ci_test and openclaw_container_runtime == 'podman'
+
+- name: Include firewall configuration tasks (Debian family)
   ansible.builtin.include_tasks: firewall-linux.yml
-  when: not ci_test
+  when: not ci_test and openclaw_firewall_backend == 'ufw'
+
+- name: Include firewall configuration tasks (RedHat family)
+  ansible.builtin.include_tasks: firewall-redhat.yml
+  when: not ci_test and openclaw_firewall_backend == 'firewalld'
 
 - name: Include Node.js installation tasks
   ansible.builtin.include_tasks: nodejs.yml
 
 - name: Include OpenClaw setup tasks
   ansible.builtin.include_tasks: openclaw.yml
+
+- name: Include rootless Quadlet tasks (RedHat family)
+  ansible.builtin.include_tasks: quadlet-redhat.yml
+  when: not ci_test and openclaw_container_runtime == 'podman'

--- a/roles/openclaw/tasks/nodejs-debian.yml
+++ b/roles/openclaw/tasks/nodejs-debian.yml
@@ -1,0 +1,43 @@
+---
+- name: Install required packages for Node.js
+  ansible.builtin.apt:
+    name:
+      - ca-certificates
+      - curl
+      - gnupg
+    state: present
+
+- name: Create directory for NodeSource GPG key
+  ansible.builtin.file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+
+- name: Add NodeSource GPG key
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | \
+        gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+      chmod a+r /etc/apt/keyrings/nodesource.gpg
+    creates: /etc/apt/keyrings/nodesource.gpg
+    executable: /bin/bash
+
+- name: Add NodeSource repository
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] \
+        https://deb.nodesource.com/node_{{ nodejs_version }} nodistro main" | \
+        tee /etc/apt/sources.list.d/nodesource.list > /dev/null
+    creates: /etc/apt/sources.list.d/nodesource.list
+    executable: /bin/bash
+
+- name: Update apt cache after adding NodeSource repo
+  ansible.builtin.apt:
+    update_cache: true
+
+- name: Install Node.js
+  ansible.builtin.apt:
+    name: nodejs
+    state: present

--- a/roles/openclaw/tasks/nodejs-redhat.yml
+++ b/roles/openclaw/tasks/nodejs-redhat.yml
@@ -1,0 +1,23 @@
+---
+- name: Install required packages for Node.js repository
+  ansible.builtin.dnf:
+    name:
+      - ca-certificates
+      - curl
+      - gnupg2
+    state: present
+
+- name: Add NodeSource RPM repository
+  ansible.builtin.yum_repository:
+    name: nodesource-nodejs
+    description: Node.js Packages for Linux RPM based distros
+    baseurl: "https://rpm.nodesource.com/pub_{{ nodejs_version }}/nodistro/nodejs/$basearch"
+    enabled: true
+    gpgcheck: true
+    gpgkey: https://rpm.nodesource.com/gpgkey/ns-operations-public.key
+
+- name: Install Node.js
+  ansible.builtin.dnf:
+    name: nodejs
+    state: present
+    update_cache: true

--- a/roles/openclaw/tasks/nodejs.yml
+++ b/roles/openclaw/tasks/nodejs.yml
@@ -1,46 +1,11 @@
 ---
-- name: Install required packages for Node.js
-  ansible.builtin.apt:
-    name:
-      - ca-certificates
-      - curl
-      - gnupg
-    state: present
+- name: Install Node.js (Debian family)
+  ansible.builtin.include_tasks: nodejs-debian.yml
+  when: ansible_os_family == 'Debian'
 
-- name: Create directory for NodeSource GPG key
-  ansible.builtin.file:
-    path: /etc/apt/keyrings
-    state: directory
-    mode: '0755'
-
-- name: Add NodeSource GPG key
-  ansible.builtin.shell:
-    cmd: |
-      set -o pipefail
-      curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | \
-        gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
-      chmod a+r /etc/apt/keyrings/nodesource.gpg
-    creates: /etc/apt/keyrings/nodesource.gpg
-    executable: /bin/bash
-
-- name: Add NodeSource repository
-  ansible.builtin.shell:
-    cmd: |
-      set -o pipefail
-      echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] \
-        https://deb.nodesource.com/node_{{ nodejs_version }} nodistro main" | \
-        tee /etc/apt/sources.list.d/nodesource.list > /dev/null
-    creates: /etc/apt/sources.list.d/nodesource.list
-    executable: /bin/bash
-
-- name: Update apt cache after adding NodeSource repo
-  ansible.builtin.apt:
-    update_cache: true
-
-- name: Install Node.js
-  ansible.builtin.apt:
-    name: nodejs
-    state: present
+- name: Install Node.js (RedHat family)
+  ansible.builtin.include_tasks: nodejs-redhat.yml
+  when: ansible_os_family == 'RedHat'
 
 - name: Check if pnpm is already installed
   ansible.builtin.command: pnpm --version

--- a/roles/openclaw/tasks/openclaw-development.yml
+++ b/roles/openclaw/tasks/openclaw-development.yml
@@ -49,7 +49,17 @@
   become_user: "{{ openclaw_user }}"
   environment:
     PNPM_HOME: "{{ openclaw_home }}/.local/share/pnpm"
-    PATH: "{{ openclaw_home }}/.local/bin:{{ openclaw_home }}/.local/share/pnpm:/usr/local/bin:/usr/bin:/bin"
+    PATH: >-
+      {{
+        [
+          openclaw_home ~ '/.local/bin',
+          openclaw_home ~ '/.local/share/pnpm/bin',
+          openclaw_home ~ '/.local/share/pnpm',
+          '/usr/local/bin',
+          '/usr/bin',
+          '/bin'
+        ] | join(':')
+      }}
     HOME: "{{ openclaw_home }}"
   register: pnpm_install_result
   changed_when: "'Already up to date' not in pnpm_install_result.stdout"
@@ -63,7 +73,17 @@
   become_user: "{{ openclaw_user }}"
   environment:
     PNPM_HOME: "{{ openclaw_home }}/.local/share/pnpm"
-    PATH: "{{ openclaw_home }}/.local/bin:{{ openclaw_home }}/.local/share/pnpm:/usr/local/bin:/usr/bin:/bin"
+    PATH: >-
+      {{
+        [
+          openclaw_home ~ '/.local/bin',
+          openclaw_home ~ '/.local/share/pnpm/bin',
+          openclaw_home ~ '/.local/share/pnpm',
+          '/usr/local/bin',
+          '/usr/bin',
+          '/bin'
+        ] | join(':')
+      }}
     HOME: "{{ openclaw_home }}"
   register: pnpm_build_result
   changed_when: true  # Build always changes dist/ directory
@@ -180,12 +200,23 @@
 - name: Verify openclaw installation from development build
   ansible.builtin.shell:
     cmd: openclaw --version
+    chdir: "{{ openclaw_home }}"
     executable: /bin/bash
   become: true
   become_user: "{{ openclaw_user }}"
   environment:
     PNPM_HOME: "{{ openclaw_home }}/.local/share/pnpm"
-    PATH: "{{ openclaw_home }}/.local/bin:{{ openclaw_home }}/.local/share/pnpm:/usr/local/bin:/usr/bin:/bin"
+    PATH: >-
+      {{
+        [
+          openclaw_home ~ '/.local/bin',
+          openclaw_home ~ '/.local/share/pnpm/bin',
+          openclaw_home ~ '/.local/share/pnpm',
+          '/usr/local/bin',
+          '/usr/bin',
+          '/bin'
+        ] | join(':')
+      }}
     HOME: "{{ openclaw_home }}"
   register: openclaw_dev_version
   changed_when: false

--- a/roles/openclaw/tasks/openclaw-release.yml
+++ b/roles/openclaw/tasks/openclaw-release.yml
@@ -4,6 +4,7 @@
 - name: Check existing OpenClaw release installation
   ansible.builtin.shell:
     cmd: openclaw --version
+    chdir: "{{ openclaw_home }}"
     executable: /bin/bash
   become: true
   become_user: "{{ openclaw_user }}"
@@ -27,7 +28,8 @@
 
 - name: Install OpenClaw globally as openclaw user (using pnpm)
   ansible.builtin.shell:
-    cmd: pnpm install -g openclaw@latest
+    cmd: timeout 600 pnpm install -g openclaw@latest --reporter append-only
+    chdir: "{{ openclaw_home }}"
     executable: /bin/bash
   become: true
   become_user: "{{ openclaw_user }}"
@@ -45,12 +47,15 @@
         ] | join(':')
       }}
     HOME: "{{ openclaw_home }}"
+    CI: "true"
+    npm_config_update_notifier: "false"
   register: openclaw_install
   changed_when: false
 
 - name: Verify openclaw installation
   ansible.builtin.shell:
     cmd: openclaw --version
+    chdir: "{{ openclaw_home }}"
     executable: /bin/bash
   become: true
   become_user: "{{ openclaw_user }}"

--- a/roles/openclaw/tasks/openclaw.yml
+++ b/roles/openclaw/tasks/openclaw.yml
@@ -161,4 +161,15 @@
       OpenClaw state directories are ready for the rootless Podman Quadlet.
       The container service will be installed and started by the RedHat-family
       Quadlet tasks.
+
+      The OpenClaw gateway runs as a rootless Podman container — there is no
+      host openclaw binary. Manage the service as the openclaw user:
+
+        sudo su - {{ openclaw_user }}
+        systemctl --user status openclaw.service
+        journalctl --user -u openclaw.service -n 100
+
+      To upgrade, pull the new image and restart:
+        podman pull {{ openclaw_podman_image }}
+        systemctl --user restart openclaw.service
   when: openclaw_container_runtime == "podman"

--- a/roles/openclaw/tasks/openclaw.yml
+++ b/roles/openclaw/tasks/openclaw.yml
@@ -83,9 +83,24 @@
         CHANGED=1
       fi
       exit $CHANGED
+    chdir: "{{ openclaw_home }}"
     executable: /bin/bash
   become: true
   become_user: "{{ openclaw_user }}"
+  environment:
+    PNPM_HOME: "{{ openclaw_home }}/.local/share/pnpm"
+    PATH: >-
+      {{
+        [
+          openclaw_home ~ '/.local/bin',
+          openclaw_home ~ '/.local/share/pnpm/bin',
+          openclaw_home ~ '/.local/share/pnpm',
+          '/usr/local/bin',
+          '/usr/bin',
+          '/bin'
+        ] | join(':')
+      }}
+    HOME: "{{ openclaw_home }}"
   register: pnpm_config_result
   changed_when: pnpm_config_result.rc == 1
   failed_when: pnpm_config_result.rc > 1
@@ -97,11 +112,15 @@
 # Include appropriate installation method based on mode
 - name: Include release installation (pnpm install -g)
   ansible.builtin.include_tasks: openclaw-release.yml
-  when: openclaw_install_mode == "release"
+  when:
+    - openclaw_install_mode == "release"
+    - openclaw_container_runtime == "docker"
 
 - name: Include development installation (git clone + build + link)
   ansible.builtin.include_tasks: openclaw-development.yml
-  when: openclaw_install_mode == "development"
+  when:
+    - openclaw_install_mode == "development"
+    - openclaw_container_runtime == "docker"
 
 - name: Configure .bashrc for openclaw user (base config)
   ansible.builtin.blockinfile:
@@ -134,3 +153,12 @@
       - Create configuration files (~/.openclaw/openclaw.json)
       - Guide you through provider setup
       - Install and start the daemon service automatically
+  when: openclaw_container_runtime == "docker"
+
+- name: Display rootless Podman configuration note
+  ansible.builtin.debug:
+    msg: |
+      OpenClaw state directories are ready for the rootless Podman Quadlet.
+      The container service will be installed and started by the RedHat-family
+      Quadlet tasks.
+  when: openclaw_container_runtime == "podman"

--- a/roles/openclaw/tasks/podman-redhat.yml
+++ b/roles/openclaw/tasks/podman-redhat.yml
@@ -30,25 +30,79 @@
       Use Fedora 38+ or a RHEL-family 9+ distribution with a current Podman package.
     success_msg: "Podman {{ openclaw_podman_version_installed }} supports Quadlets."
 
+- name: Check for existing subuid allocation for openclaw user
+  ansible.builtin.shell:
+    cmd: "grep -E '^{{ openclaw_user }}:' /etc/subuid || true"
+    executable: /bin/bash
+  register: openclaw_existing_subuid
+  changed_when: false
+
+- name: Check for existing subgid allocation for openclaw user
+  ansible.builtin.shell:
+    cmd: "grep -E '^{{ openclaw_user }}:' /etc/subgid || true"
+    executable: /bin/bash
+  register: openclaw_existing_subgid
+  changed_when: false
+
+- name: Find highest allocated subuid end to avoid overlap
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      awk -F: '{print $2+$3}' /etc/subuid 2>/dev/null | sort -n | tail -1 || echo 0
+    executable: /bin/bash
+  register: openclaw_subuid_max
+  changed_when: false
+  when: openclaw_existing_subuid.stdout == ''
+
+- name: Find highest allocated subgid end to avoid overlap
+  ansible.builtin.shell:
+    cmd: |
+      set -o pipefail
+      awk -F: '{print $2+$3}' /etc/subgid 2>/dev/null | sort -n | tail -1 || echo 0
+    executable: /bin/bash
+  register: openclaw_subgid_max
+  changed_when: false
+  when: openclaw_existing_subgid.stdout == ''
+
+- name: Compute safe subuid start (above existing allocations)
+  ansible.builtin.set_fact:
+    openclaw_computed_subuid_start: >-
+      {{
+        [openclaw_podman_subuid_start, (openclaw_subuid_max.stdout | int)]
+        | max
+      }}
+  when: openclaw_existing_subuid.stdout == ''
+
+- name: Compute safe subgid start (above existing allocations)
+  ansible.builtin.set_fact:
+    openclaw_computed_subgid_start: >-
+      {{
+        [openclaw_podman_subgid_start, (openclaw_subgid_max.stdout | int)]
+        | max
+      }}
+  when: openclaw_existing_subgid.stdout == ''
+
 - name: Ensure subuid range for rootless Podman user
   ansible.builtin.lineinfile:
     path: /etc/subuid
     regexp: "^{{ openclaw_user }}:"
-    line: "{{ openclaw_user }}:{{ openclaw_podman_subuid_start }}:{{ openclaw_podman_subid_count }}"
+    line: "{{ openclaw_user }}:{{ openclaw_computed_subuid_start | default(openclaw_podman_subuid_start) }}:{{ openclaw_podman_subid_count }}"
     create: true
     owner: root
     group: root
     mode: '0644'
+  when: openclaw_existing_subuid.stdout == ''
 
 - name: Ensure subgid range for rootless Podman user
   ansible.builtin.lineinfile:
     path: /etc/subgid
     regexp: "^{{ openclaw_user }}:"
-    line: "{{ openclaw_user }}:{{ openclaw_podman_subgid_start }}:{{ openclaw_podman_subid_count }}"
+    line: "{{ openclaw_user }}:{{ openclaw_computed_subgid_start | default(openclaw_podman_subgid_start) }}:{{ openclaw_podman_subid_count }}"
     create: true
     owner: root
     group: root
     mode: '0644'
+  when: openclaw_existing_subgid.stdout == ''
 
 - name: Check lingering state for rootless Podman user
   ansible.builtin.stat:

--- a/roles/openclaw/tasks/podman-redhat.yml
+++ b/roles/openclaw/tasks/podman-redhat.yml
@@ -1,0 +1,87 @@
+---
+# RedHat-family rootless Podman setup. Rootful Podman units and system Quadlet
+# directories are intentionally not managed here.
+
+- name: Verify systemd user tooling exists for rootless Quadlets
+  ansible.builtin.command: "{{ item }} --version"
+  loop:
+    - systemctl
+    - loginctl
+  register: openclaw_systemd_tooling
+  changed_when: false
+
+- name: Check installed Podman version
+  ansible.builtin.command: podman --version
+  register: openclaw_podman_version_cmd
+  changed_when: false
+
+- name: Parse installed Podman version
+  ansible.builtin.set_fact:
+    openclaw_podman_version_installed: >-
+      {{ openclaw_podman_version_cmd.stdout | regex_search('[0-9]+\.[0-9]+\.[0-9]+') }}
+
+- name: Fail if Podman does not support Quadlets
+  ansible.builtin.assert:
+    that:
+      - openclaw_podman_version_installed is version(openclaw_podman_min_version, '>=')
+    fail_msg: >-
+      Installed Podman {{ openclaw_podman_version_installed | default('unknown') }} is too old.
+      Rootless Quadlets require Podman {{ openclaw_podman_min_version }} or newer.
+      Use Fedora 38+ or a RHEL-family 9+ distribution with a current Podman package.
+    success_msg: "Podman {{ openclaw_podman_version_installed }} supports Quadlets."
+
+- name: Ensure subuid range for rootless Podman user
+  ansible.builtin.lineinfile:
+    path: /etc/subuid
+    regexp: "^{{ openclaw_user }}:"
+    line: "{{ openclaw_user }}:{{ openclaw_podman_subuid_start }}:{{ openclaw_podman_subid_count }}"
+    create: true
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Ensure subgid range for rootless Podman user
+  ansible.builtin.lineinfile:
+    path: /etc/subgid
+    regexp: "^{{ openclaw_user }}:"
+    line: "{{ openclaw_user }}:{{ openclaw_podman_subgid_start }}:{{ openclaw_podman_subid_count }}"
+    create: true
+    owner: root
+    group: root
+    mode: '0644'
+
+- name: Check lingering state for rootless Podman user
+  ansible.builtin.stat:
+    path: "/var/lib/systemd/linger/{{ openclaw_user }}"
+  register: openclaw_linger_file
+
+- name: Enable lingering for rootless Podman user
+  ansible.builtin.command: "loginctl enable-linger {{ openclaw_user }}"
+  when: not openclaw_linger_file.stat.exists
+  changed_when: true
+
+- name: Start user systemd manager for rootless Podman user
+  ansible.builtin.systemd:
+    name: "user@{{ openclaw_uid_value }}.service"
+    state: started
+  when: openclaw_uid_value is defined
+
+- name: Verify Podman reports rootless mode as the OpenClaw user
+  ansible.builtin.command:
+    cmd: podman info --format '{{ "{{" }}.Host.Security.Rootless{{ "}}" }}'
+  become: true
+  become_user: "{{ openclaw_user }}"
+  environment:
+    HOME: "{{ openclaw_home }}"
+    XDG_RUNTIME_DIR: "/run/user/{{ openclaw_uid_value }}"
+  register: openclaw_podman_rootless_info
+  changed_when: false
+
+- name: Assert Podman is rootless for the OpenClaw user
+  ansible.builtin.assert:
+    that:
+      - openclaw_podman_rootless_info.stdout | trim == 'true'
+    fail_msg: >-
+      Podman did not report rootless mode for {{ openclaw_user }}. The installer
+      will not fall back to rootful Podman. Check subuid/subgid ranges, lingering,
+      and user systemd availability.

--- a/roles/openclaw/tasks/preflight.yml
+++ b/roles/openclaw/tasks/preflight.yml
@@ -1,0 +1,59 @@
+---
+- name: Detect supported OpenClaw installer OS family
+  ansible.builtin.assert:
+    that:
+      - ansible_system == 'Linux'
+      - ansible_os_family in ['Debian', 'RedHat']
+    fail_msg: >-
+      Unsupported operating system or OS family: {{ ansible_system }} / {{ ansible_os_family }}.
+      Supported platforms are Debian 11+, Ubuntu 20.04+, Fedora 38+, and
+      RHEL-family 9+ systems with rootless Podman Quadlet support.
+
+- name: Load OS-family variables
+  ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
+
+- name: Detect supported OpenClaw installer platform
+  ansible.builtin.set_fact:
+    openclaw_is_debian_supported: "{{ ansible_distribution in ['Debian', 'Ubuntu'] }}"
+    openclaw_is_fedora_supported: >-
+      {{ ansible_distribution == 'Fedora' and (ansible_distribution_major_version | int) >= 38 }}
+    openclaw_is_el_supported: >-
+      {{
+        ansible_distribution in [
+          'RedHat',
+          'Red Hat Enterprise Linux',
+          'CentOS',
+          'CentOS Stream',
+          'AlmaLinux',
+          'Rocky',
+          'OracleLinux',
+          'Oracle Linux'
+        ]
+        and (ansible_distribution_major_version | int) >= 9
+      }}
+
+- name: Fail on unsupported Linux distribution
+  ansible.builtin.fail:
+    msg: >-
+      Unsupported Linux distribution: {{ ansible_distribution }} {{ ansible_distribution_version }}.
+      Supported platforms are Debian 11+, Ubuntu 20.04+, Fedora 38+, and
+      RHEL-family 9+ systems with rootless Podman Quadlet support. CentOS 7 and
+      RHEL-family 7/8 are not supported because the installer requires rootless
+      Podman Quadlets.
+  when:
+    - not (openclaw_is_debian_supported or openclaw_is_fedora_supported or openclaw_is_el_supported)
+
+- name: Reject rootful Podman configuration
+  ansible.builtin.assert:
+    that:
+      - openclaw_user != 'root'
+      - (container_runtime | default(openclaw_container_runtime)) == 'podman'
+      - (podman_mode | default(openclaw_podman_mode)) == 'rootless'
+      - not (openclaw_rootful_podman | bool)
+      - not (rootful_podman | default(false) | bool)
+    fail_msg: >-
+      RedHat-family installs support rootless Podman only. Set openclaw_user to
+      a non-root user and do not request rootful Podman; rootful Podman is
+      intentionally unsupported and has no fallback path.
+    success_msg: "RedHat-family container runtime policy is rootless Podman only."
+  when: ansible_os_family == 'RedHat'

--- a/roles/openclaw/tasks/quadlet-redhat.yml
+++ b/roles/openclaw/tasks/quadlet-redhat.yml
@@ -1,0 +1,121 @@
+---
+# Rootless Podman Quadlet for RedHat-family installs. The file is owned by the
+# app user under ~/.config/containers/systemd; system Quadlet directories are never used.
+
+- name: Check for existing OpenClaw container environment
+  ansible.builtin.stat:
+    path: "{{ openclaw_config_dir }}/.env"
+  register: openclaw_container_env_stat
+
+- name: Generate OpenClaw gateway token for container environment
+  ansible.builtin.command: openssl rand -hex 32
+  register: openclaw_gateway_token
+  changed_when: true
+  no_log: true
+  when: not openclaw_container_env_stat.stat.exists
+
+- name: Create OpenClaw container environment file
+  ansible.builtin.copy:
+    dest: "{{ openclaw_config_dir }}/.env"
+    owner: "{{ openclaw_user }}"
+    group: "{{ openclaw_user }}"
+    mode: '0600'
+    content: |
+      OPENCLAW_GATEWAY_TOKEN={{ openclaw_gateway_token.stdout }}
+  no_log: true
+  when: not openclaw_container_env_stat.stat.exists
+
+- name: Persist rootless Podman container name
+  ansible.builtin.lineinfile:
+    path: "{{ openclaw_config_dir }}/.env"
+    regexp: '^OPENCLAW_PODMAN_CONTAINER='
+    line: "OPENCLAW_PODMAN_CONTAINER={{ openclaw_podman_container_name }}"
+    create: true
+    owner: "{{ openclaw_user }}"
+    group: "{{ openclaw_user }}"
+    mode: '0600'
+
+- name: Persist rootless Podman image
+  ansible.builtin.lineinfile:
+    path: "{{ openclaw_config_dir }}/.env"
+    regexp: '^OPENCLAW_PODMAN_IMAGE='
+    line: "OPENCLAW_PODMAN_IMAGE={{ openclaw_podman_image }}"
+    create: true
+    owner: "{{ openclaw_user }}"
+    group: "{{ openclaw_user }}"
+    mode: '0600'
+
+- name: Check for existing OpenClaw JSON config
+  ansible.builtin.stat:
+    path: "{{ openclaw_config_dir }}/openclaw.json"
+  register: openclaw_json_config_stat
+
+- name: Create minimal container gateway config
+  ansible.builtin.copy:
+    dest: "{{ openclaw_config_dir }}/openclaw.json"
+    owner: "{{ openclaw_user }}"
+    group: "{{ openclaw_user }}"
+    mode: '0600'
+    content: |
+      {
+        "gateway": {
+          "mode": "local",
+          "controlUi": {
+            "allowedOrigins": [
+              "http://127.0.0.1:{{ openclaw_podman_gateway_host_port }}",
+              "http://localhost:{{ openclaw_podman_gateway_host_port }}"
+            ]
+          }
+        }
+      }
+  when: not openclaw_json_config_stat.stat.exists
+
+- name: Ensure rootless Quadlet directory exists
+  ansible.builtin.file:
+    path: "{{ openclaw_quadlet_dir }}"
+    state: directory
+    owner: "{{ openclaw_user }}"
+    group: "{{ openclaw_user }}"
+    mode: '0755'
+
+- name: Install rootless OpenClaw Quadlet
+  ansible.builtin.template:
+    src: openclaw.container.j2
+    dest: "{{ openclaw_quadlet_dir }}/openclaw.container"
+    owner: "{{ openclaw_user }}"
+    group: "{{ openclaw_user }}"
+    mode: '0644'
+  register: openclaw_quadlet_template
+
+- name: Reload rootless user systemd for Quadlet
+  ansible.builtin.command: systemctl --user daemon-reload
+  become: true
+  become_user: "{{ openclaw_user }}"
+  environment:
+    HOME: "{{ openclaw_home }}"
+    XDG_RUNTIME_DIR: "/run/user/{{ openclaw_uid_value }}"
+  changed_when: openclaw_quadlet_template.changed
+
+- name: Check rootless OpenClaw Quadlet service state
+  ansible.builtin.command: "systemctl --user is-active --quiet {{ openclaw_quadlet_service_name }}"
+  become: true
+  become_user: "{{ openclaw_user }}"
+  environment:
+    HOME: "{{ openclaw_home }}"
+    XDG_RUNTIME_DIR: "/run/user/{{ openclaw_uid_value }}"
+  register: openclaw_quadlet_active
+  changed_when: false
+  failed_when: false
+
+- name: Start or restart rootless OpenClaw Quadlet service
+  ansible.builtin.command: >-
+    systemctl --user
+    {{ 'restart' if openclaw_quadlet_template.changed else 'start' }}
+    {{ openclaw_quadlet_service_name }}
+  become: true
+  become_user: "{{ openclaw_user }}"
+  environment:
+    HOME: "{{ openclaw_home }}"
+    XDG_RUNTIME_DIR: "/run/user/{{ openclaw_uid_value }}"
+  when: openclaw_quadlet_template.changed or openclaw_quadlet_active.rc != 0
+  changed_when: true

--- a/roles/openclaw/tasks/quadlet-redhat.yml
+++ b/roles/openclaw/tasks/quadlet-redhat.yml
@@ -107,6 +107,15 @@
   changed_when: false
   failed_when: false
 
+- name: Enable rootless OpenClaw Quadlet service (persist across reboot)
+  ansible.builtin.command: "systemctl --user enable {{ openclaw_quadlet_service_name }}"
+  become: true
+  become_user: "{{ openclaw_user }}"
+  environment:
+    HOME: "{{ openclaw_home }}"
+    XDG_RUNTIME_DIR: "/run/user/{{ openclaw_uid_value }}"
+  changed_when: openclaw_quadlet_template.changed
+
 - name: Start or restart rootless OpenClaw Quadlet service
   ansible.builtin.command: >-
     systemctl --user

--- a/roles/openclaw/tasks/system-tools-linux.yml
+++ b/roles/openclaw/tasks/system-tools-linux.yml
@@ -3,45 +3,7 @@
 
 - name: Install essential system tools (Linux - apt)
   ansible.builtin.apt:
-    name:
-      # Editors
-      - vim
-      - nano
-      # Version control
-      - git
-      - git-lfs
-      # Network tools
-      - curl
-      - wget
-      - netcat-openbsd
-      - net-tools
-      - dnsutils
-      - iputils-ping
-      - traceroute
-      - tcpdump
-      - nmap
-      - socat
-      - telnet
-      # Debugging tools
-      - strace
-      - lsof
-      - gdb
-      - htop
-      - iotop
-      - iftop
-      - sysstat
-      - procps
-      # System utilities
-      - tmux
-      - tree
-      - jq
-      - unzip
-      - rsync
-      - less
-      - sudo
-      # Build essentials for development
-      - build-essential
-      - file
+    name: "{{ openclaw_system_packages }}"
     state: present
     update_cache: true
 

--- a/roles/openclaw/tasks/system-tools-redhat.yml
+++ b/roles/openclaw/tasks/system-tools-redhat.yml
@@ -1,0 +1,16 @@
+---
+# Linux-specific system tools installation (RedHat family - dnf)
+
+- name: Install essential system tools (RedHat family - dnf)
+  ansible.builtin.dnf:
+    name: "{{ openclaw_system_packages }}"
+    state: present
+    update_cache: true
+
+- name: Deploy global vim configuration (RedHat family)
+  ansible.builtin.template:
+    src: vimrc.j2
+    dest: /etc/vimrc.local
+    owner: root
+    group: root
+    mode: '0644'

--- a/roles/openclaw/tasks/system-tools.yml
+++ b/roles/openclaw/tasks/system-tools.yml
@@ -1,8 +1,13 @@
 ---
 # Main system tools orchestration - Linux only
 
-- name: Include Linux system tools installation
+- name: Include Linux system tools installation (Debian family)
   ansible.builtin.include_tasks: system-tools-linux.yml
+  when: ansible_os_family == 'Debian'
+
+- name: Include Linux system tools installation (RedHat family)
+  ansible.builtin.include_tasks: system-tools-redhat.yml
+  when: ansible_os_family == 'RedHat'
 
 # Common tasks for all operating systems
 

--- a/roles/openclaw/tasks/tailscale-redhat.yml
+++ b/roles/openclaw/tasks/tailscale-redhat.yml
@@ -1,0 +1,58 @@
+---
+# RedHat-family Tailscale installation.
+
+- name: Configure Tailscale repository (Fedora)
+  ansible.builtin.yum_repository:
+    name: tailscale-stable
+    description: Tailscale stable
+    baseurl: https://pkgs.tailscale.com/stable/fedora/$basearch
+    enabled: true
+    repo_gpgcheck: true
+    gpgcheck: true
+    gpgkey: https://pkgs.tailscale.com/stable/fedora/repo.gpg
+  when: ansible_distribution == 'Fedora'
+
+- name: Configure Tailscale repository (RHEL family)
+  ansible.builtin.yum_repository:
+    name: tailscale-stable
+    description: Tailscale stable
+    baseurl: "https://pkgs.tailscale.com/stable/centos/{{ ansible_distribution_major_version }}/$basearch"
+    enabled: true
+    repo_gpgcheck: true
+    gpgcheck: true
+    gpgkey: "https://pkgs.tailscale.com/stable/centos/{{ ansible_distribution_major_version }}/repo.gpg"
+  when: ansible_distribution != 'Fedora'
+
+- name: Install Tailscale (RedHat family)
+  ansible.builtin.dnf:
+    name: tailscale
+    state: present
+    update_cache: true
+
+- name: Enable Tailscale service (RedHat family)
+  ansible.builtin.systemd:
+    name: tailscaled
+    enabled: true
+    state: started
+
+- name: Check if Tailscale is already connected (RedHat family)
+  ansible.builtin.command: tailscale status --json
+  register: tailscale_status_redhat
+  changed_when: false
+  failed_when: false
+
+- name: Display Tailscale auth URL if not connected (RedHat family)
+  ansible.builtin.debug:
+    msg:
+      - "============================================"
+      - "Tailscale installed but not connected yet"
+      - "============================================"
+      - ""
+      - "To connect this machine to your Tailnet:"
+      - "Run: sudo tailscale up"
+      - ""
+      - "For unattended installation, use an auth key:"
+      - "sudo tailscale up --authkey tskey-auth-xxxxx"
+      - ""
+      - "Get auth key from: https://login.tailscale.com/admin/settings/keys"
+  when: tailscale_status_redhat.rc != 0

--- a/roles/openclaw/tasks/user.yml
+++ b/roles/openclaw/tasks/user.yml
@@ -112,12 +112,12 @@
   ansible.builtin.command: "id -u {{ openclaw_user }}"
   register: openclaw_uid
   changed_when: false
-  when: ansible_os_family == 'Debian' and not ci_test
+  when: not ci_test
 
 - name: Display openclaw user ID
   ansible.builtin.debug:
     msg: "OpenClaw user ID: {{ openclaw_uid.stdout }}"
-  when: ansible_os_family == 'Debian' and not ci_test
+  when: not ci_test
 
 - name: Enable lingering for openclaw user (allows systemd user services without login)
   ansible.builtin.command: "loginctl enable-linger {{ openclaw_user }}"
@@ -136,7 +136,7 @@
 - name: Store openclaw UID as fact for later use
   ansible.builtin.set_fact:
     openclaw_uid_value: "{{ openclaw_uid.stdout }}"
-  when: ansible_os_family == 'Debian' and not ci_test
+  when: not ci_test
 
 # SSH key configuration
 - name: Create .ssh directory for openclaw user
@@ -174,7 +174,7 @@
     owner: "{{ openclaw_user }}"
     group: "{{ openclaw_user }}"
     mode: '0644'
-  when: ansible_os_family == 'Debian' and not ci_test
+  when: not ci_test
 
 - name: Set DBUS_SESSION_BUS_ADDRESS in .bashrc for openclaw user
   ansible.builtin.blockinfile:
@@ -189,4 +189,4 @@
     owner: "{{ openclaw_user }}"
     group: "{{ openclaw_user }}"
     mode: '0644'
-  when: ansible_os_family == 'Debian' and not ci_test
+  when: not ci_test

--- a/roles/openclaw/templates/openclaw.container.j2
+++ b/roles/openclaw/templates/openclaw.container.j2
@@ -20,7 +20,7 @@ Environment=NPM_CONFIG_CACHE=/home/node/.openclaw/.npm
 Environment=OPENCLAW_NO_RESPAWN=1
 PublishPort=127.0.0.1:{{ openclaw_podman_gateway_host_port }}:18789
 PublishPort=127.0.0.1:{{ openclaw_podman_bridge_host_port }}:18790
-Pull=always
+Pull=newer
 Exec=node dist/index.js gateway --bind lan --port 18789
 
 [Service]

--- a/roles/openclaw/templates/openclaw.container.j2
+++ b/roles/openclaw/templates/openclaw.container.j2
@@ -1,0 +1,31 @@
+# OpenClaw gateway - rootless Podman Quadlet
+# Managed by openclaw-ansible for RedHat-family installs only.
+
+[Unit]
+Description=OpenClaw gateway (rootless Podman)
+Wants=network-online.target
+After=network-online.target
+
+[Container]
+Image={{ openclaw_podman_image }}
+ContainerName={{ openclaw_podman_container_name }}
+UserNS=keep-id
+User=%U:%G
+Volume={{ openclaw_config_dir }}:/home/node/.openclaw:Z
+Volume={{ openclaw_config_dir }}/workspace:/home/node/.openclaw/workspace:Z
+EnvironmentFile={{ openclaw_config_dir }}/.env
+Environment=HOME=/home/node
+Environment=TERM=xterm-256color
+Environment=NPM_CONFIG_CACHE=/home/node/.openclaw/.npm
+Environment=OPENCLAW_NO_RESPAWN=1
+PublishPort=127.0.0.1:{{ openclaw_podman_gateway_host_port }}:18789
+PublishPort=127.0.0.1:{{ openclaw_podman_bridge_host_port }}:18790
+Pull=always
+Exec=node dist/index.js gateway --bind lan --port 18789
+
+[Service]
+TimeoutStartSec=300
+Restart=on-failure
+
+[Install]
+WantedBy=default.target

--- a/roles/openclaw/templates/show-lobster.sh.j2
+++ b/roles/openclaw/templates/show-lobster.sh.j2
@@ -8,7 +8,7 @@ cat << 'LOBSTER'
    |                                                    |
    |[0;31m                   ,.---._                         [0;36m|
    |[0;31m               ,,,,     /       `,                 [0;36m|
-   |[0;31m                \\\   /    '\_  ;                [0;36m|
+   |[0;31m                \\   /    '\_  ;                [0;36m|
    |[0;31m                 |||| /\/``-.__\;'                 [0;36m|
    |[0;31m                 ::::/\/_                          [0;36m|
    |[0;31m {{`-.__.-'(`(^^(^^^(^ 9 `.========='              [0;36m|
@@ -27,15 +27,25 @@ LOBSTER
 
 echo ""
 echo "🔒 Security Status:"
-echo "  - UFW Firewall: ENABLED"
 {% endraw %}
+{% if ansible_os_family == 'RedHat' %}
+echo "  - Firewall: firewalld ENABLED"
 {% if tailscale_enabled | default(false) %}
 echo "  - Open Ports: SSH (22) + Tailscale (41641/udp)"
 {% else %}
 echo "  - Open Ports: SSH (22)"
 {% endif %}
-{% raw %}
+echo "  - Rootless Podman Quadlet: ACTIVE"
+{% else %}
+echo "  - Firewall: UFW ENABLED"
+{% if tailscale_enabled | default(false) %}
+echo "  - Open Ports: SSH (22) + Tailscale (41641/udp)"
+{% else %}
+echo "  - Open Ports: SSH (22)"
+{% endif %}
 echo "  - Docker isolation: ACTIVE"
+{% endif %}
+{% raw %}
 echo ""
 echo "📚 Documentation: https://github.com/openclaw/openclaw-ansible"
 echo ""

--- a/roles/openclaw/vars/Debian.yml
+++ b/roles/openclaw/vars/Debian.yml
@@ -1,0 +1,37 @@
+---
+openclaw_container_runtime: docker
+openclaw_firewall_backend: ufw
+openclaw_linux_package_manager: apt
+openclaw_system_packages:
+  - vim
+  - nano
+  - git
+  - git-lfs
+  - curl
+  - wget
+  - netcat-openbsd
+  - net-tools
+  - dnsutils
+  - iputils-ping
+  - traceroute
+  - tcpdump
+  - nmap
+  - socat
+  - telnet
+  - strace
+  - lsof
+  - gdb
+  - htop
+  - iotop
+  - iftop
+  - sysstat
+  - procps
+  - tmux
+  - tree
+  - jq
+  - unzip
+  - rsync
+  - less
+  - sudo
+  - build-essential
+  - file

--- a/roles/openclaw/vars/RedHat.yml
+++ b/roles/openclaw/vars/RedHat.yml
@@ -1,0 +1,63 @@
+---
+openclaw_container_runtime: podman
+openclaw_podman_mode: rootless
+openclaw_podman_min_version: "4.4.0"
+openclaw_firewall_backend: firewalld
+openclaw_linux_package_manager: dnf
+openclaw_quadlet_dir: "{{ openclaw_home }}/.config/containers/systemd"
+openclaw_quadlet_service_name: openclaw.service
+openclaw_podman_image: ghcr.io/openclaw/openclaw:latest
+openclaw_podman_container_name: openclaw
+openclaw_podman_gateway_host_port: 18789
+openclaw_podman_bridge_host_port: 18790
+openclaw_podman_subuid_start: 100000
+openclaw_podman_subgid_start: 100000
+openclaw_podman_subid_count: 65536
+openclaw_rootful_podman: false
+openclaw_firewalld_zone: public
+openclaw_system_packages:
+  - vim-enhanced
+  - nano
+  - git
+  - curl
+  - wget
+  - nmap-ncat
+  - net-tools
+  - bind-utils
+  - iputils
+  - traceroute
+  - tcpdump
+  - nmap
+  - socat
+  - telnet
+  - strace
+  - lsof
+  - gdb
+  - sysstat
+  - procps-ng
+  - tmux
+  - tree
+  - jq
+  - unzip
+  - rsync
+  - less
+  - sudo
+  - gcc
+  - gcc-c++
+  - make
+  - file
+  - acl
+  - ca-certificates
+  - gnupg2
+  - openssl
+  - python3
+  - python3-pip
+  - python3-libselinux
+  - shadow-utils
+  - dbus-daemon
+  - podman
+  - slirp4netns
+  - fuse-overlayfs
+  - firewalld
+  - container-selinux
+  - policycoreutils-python-utils

--- a/roles/openclaw/vars/RedHat.yml
+++ b/roles/openclaw/vars/RedHat.yml
@@ -1,7 +1,7 @@
 ---
 openclaw_container_runtime: podman
 openclaw_podman_mode: rootless
-openclaw_podman_min_version: "4.4.0"
+openclaw_podman_min_version: "4.5.0"
 openclaw_firewall_backend: firewalld
 openclaw_linux_package_manager: dnf
 openclaw_quadlet_dir: "{{ openclaw_home }}/.config/containers/systemd"

--- a/roles/openclaw/vars/RedHat.yml
+++ b/roles/openclaw/vars/RedHat.yml
@@ -6,7 +6,9 @@ openclaw_firewall_backend: firewalld
 openclaw_linux_package_manager: dnf
 openclaw_quadlet_dir: "{{ openclaw_home }}/.config/containers/systemd"
 openclaw_quadlet_service_name: openclaw.service
-openclaw_podman_image: ghcr.io/openclaw/openclaw:latest
+openclaw_podman_image_repo: ghcr.io/openclaw/openclaw
+openclaw_podman_image_tag: latest
+openclaw_podman_image: "{{ openclaw_podman_image_repo }}:{{ openclaw_podman_image_tag }}"
 openclaw_podman_container_name: openclaw
 openclaw_podman_gateway_host_port: 18789
 openclaw_podman_bridge_host_port: 18790

--- a/tests/verify-redhat-static.yml
+++ b/tests/verify-redhat-static.yml
@@ -1,0 +1,37 @@
+---
+- name: Verify RedHat-family static rootless Podman policy
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  tasks:
+    - name: Read role tasks and templates
+      ansible.builtin.slurp:
+        src: "{{ item }}"
+      loop:
+        - "{{ playbook_dir }}/../roles/openclaw/tasks/main.yml"
+        - "{{ playbook_dir }}/../roles/openclaw/tasks/podman-redhat.yml"
+        - "{{ playbook_dir }}/../roles/openclaw/tasks/quadlet-redhat.yml"
+        - "{{ playbook_dir }}/../roles/openclaw/templates/openclaw.container.j2"
+      register: openclaw_static_files
+
+    - name: Combine static file contents
+      ansible.builtin.set_fact:
+        openclaw_static_content: >-
+          {{ openclaw_static_files.results | map(attribute='content') | map('b64decode') | join('\n') }}
+
+    - name: Assert rootless-only Quadlet policy
+      ansible.builtin.assert:
+        that:
+          - "'/etc/containers/systemd' not in openclaw_static_content"
+          - "'podman.service' not in openclaw_static_content"
+          - "'podman.socket' not in openclaw_static_content"
+          - "'systemctl --user daemon-reload' in openclaw_static_content"
+          - "'systemctl --user is-active --quiet' in openclaw_static_content"
+          - "'become_user:' in openclaw_static_content"
+          - "'openclaw_user' in openclaw_static_content"
+          - "'XDG_RUNTIME_DIR:' in openclaw_static_content"
+          - "'openclaw_uid_value' in openclaw_static_content"
+          - "'UserNS=keep-id' in openclaw_static_content"
+          - "':/home/node/.openclaw:Z' in openclaw_static_content"
+        fail_msg: RedHat-family Podman support must stay rootless-only and Quadlet-backed.

--- a/tests/verify-redhat-static.yml
+++ b/tests/verify-redhat-static.yml
@@ -27,6 +27,7 @@
           - "'podman.service' not in openclaw_static_content"
           - "'podman.socket' not in openclaw_static_content"
           - "'systemctl --user daemon-reload' in openclaw_static_content"
+          - "'systemctl --user enable' in openclaw_static_content"
           - "'systemctl --user is-active --quiet' in openclaw_static_content"
           - "'become_user:' in openclaw_static_content"
           - "'openclaw_user' in openclaw_static_content"

--- a/tests/verify.yml
+++ b/tests/verify.yml
@@ -13,10 +13,17 @@
       ansible.builtin.command: "id {{ openclaw_user }}"
       changed_when: false
 
-    - name: Verify critical packages installed
+    - name: Verify critical packages installed (Debian family)
       ansible.builtin.command: "dpkg -s {{ item }}"
       loop: [git, curl, vim, jq, tmux, tree, htop, sudo]
       changed_when: false
+      when: ansible_os_family == 'Debian'
+
+    - name: Verify critical packages installed (RedHat family)
+      ansible.builtin.command: "rpm -q {{ item }}"
+      loop: [git, curl, vim-enhanced, jq, tmux, tree, sudo, podman, firewalld]
+      changed_when: false
+      when: ansible_os_family == 'RedHat'
 
     - name: Verify Node.js installed
       ansible.builtin.command: node --version
@@ -63,7 +70,7 @@
 
     - name: Verify global vim config exists
       ansible.builtin.stat:
-        path: /etc/vim/vimrc.local
+        path: "{{ '/etc/vimrc.local' if ansible_os_family == 'RedHat' else '/etc/vim/vimrc.local' }}"
       register: vimrc
     - ansible.builtin.assert:
         that: vimrc.stat.exists


### PR DESCRIPTION
## Summary

Extends the installer from Debian/Ubuntu-only to dual-platform support for **Fedora 38+** and **RHEL-family 9+** systems (RHEL, AlmaLinux, Rocky, CentOS Stream, Oracle Linux, etc.).

No changes to existing Debian/Ubuntu Docker + UFW behavior.

---

## Platform additions

- **`preflight.yml`** — OS family detection, version gating, and rootless-only policy enforcement; fails fast on rootful Podman or unsupported distros
- **`podman-redhat.yml`** — rootless Podman setup: subuid/subgid ranges, lingering, user systemd manager, rootless assertion
- **`firewall-redhat.yml`** — firewalld-backed SSH + optional Tailscale port rules
- **`quadlet-redhat.yml`** — rootless Quadlet under `~/.config/containers/systemd`, user-scoped systemd lifecycle (daemon-reload, start/restart)
- **`tailscale-redhat.yml`** — Fedora/RHEL-family Tailscale repo + install
- **`nodejs-{debian,redhat}.yml`** — split NodeSource setup by OS family
- **`system-tools-redhat.yml`** — dnf-based tooling install
- **`vars/{Debian,RedHat}.yml`** — per-family package lists, runtime, firewall, and Podman variables loaded by preflight
- **`templates/openclaw.container.j2`** — rootless Quadlet with `UserNS=keep-id`, localhost port bindings, and `:Z` SELinux volume labels

## Orchestration changes

- `main.yml` — family-gated `include_tasks` for all OS-split task files
- `system-tools.yml`, `nodejs.yml` — delegate to family-specific subtasks
- `playbooks/deploy.yml` + `install.yml` — RedHat family detection and updated distro support error messages
- `install.sh` — dnf/yum detection and package manager-aware bootstrap
- `user.yml` — remove Debian-only guards from UID fact and lingering tasks

## Tests

- **`tests/verify-redhat-static.yml`** — static policy assertions: Quadlets are rootless-only, use user systemd, carry `:Z` SELinux labels, and never reference system Quadlet directories
- **`tests/verify.yml`** — RedHat rpm-based package checks + vimrc path branching

## Docs / meta

- `AGENTS.md`, `README.md`, `docs/` — updated for dual-platform scope
- `galaxy.yml` — updated description and tags (docker, podman, firewalld, ufw)
- `show-lobster.sh.j2` — family-aware security status display
- `openclaw-{development,release}.yml`, `openclaw.yml` — add `pnpm/bin` to PATH, `chdir` to home, guard Docker-only install tasks

## Testing checklist

- [x] `ansible-playbook playbook.yml --syntax-check`
- [x] `ansible-playbook playbooks/deploy.yml --syntax-check`
- [x] `ansible-playbook tests/verify.yml --syntax-check`
- [x] `ansible-playbook tests/verify-redhat-static.yml --syntax-check`
- [x] `ansible-playbook tests/verify-redhat-static.yml` (static policy assertions pass)
- [ ] Full Debian/Ubuntu install on disposable VM
- [ ] Full Fedora/RHEL install on disposable VM