### PR TITLE
fix(tailscale): auto-connect with authkey, detect NeedsLogin, enable Tailscale SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Edit `roles/openclaw/defaults/main.yml` before running the playbook.
 | `openclaw_repo_url` | `https://github.com/openclaw/openclaw.git` | Git repository (dev mode) |
 | `openclaw_repo_branch` | `main` | Git branch (dev mode) |
 | `tailscale_authkey` | `""` | Tailscale auth key for auto-connect |
+| `tailscale_ssh` | `false` | Enable Tailscale SSH (`--ssh`) when joining the tailnet |
 | `nodejs_version` | `22.x` | Node.js version to install |
 
 See [`roles/openclaw/defaults/main.yml`](roles/openclaw/defaults/main.yml) for the complete list.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -179,6 +179,15 @@ These variables only apply when `openclaw_install_mode: development`
   ```
 - **Get Key**: https://login.tailscale.com/admin/settings/keys
 
+#### `tailscale_ssh`
+- **Type**: Boolean
+- **Default**: `false` (opt-in)
+- **Description**: Passes `--ssh` to `tailscale up` when joining the tailnet, enabling [Tailscale SSH](https://tailscale.com/kb/1193/tailscale-ssh) to the node. Requires your tailnet ACLs to also permit SSH to the node (an `ssh` rule / appropriate tags) — this setting only controls the client-side flag.
+- **Example**:
+  ```bash
+  -e tailscale_ssh=true
+  ```
+
 ### OS-Specific Settings
 
 These are automatically set based on the detected OS:

--- a/roles/openclaw/defaults/main.yml
+++ b/roles/openclaw/defaults/main.yml
@@ -8,6 +8,7 @@ ci_test: false
 # WARNING: Tasks using tailscale_authkey MUST set no_log: true to prevent credential exposure
 tailscale_enabled: false  # Set to true to install and configure Tailscale
 tailscale_authkey: ""  # Optional: set to auto-connect during installation
+tailscale_ssh: true  # Enable Tailscale SSH (tailscale up --ssh) when joining the tailnet
 
 # Node.js version
 nodejs_version: "22.x"

--- a/roles/openclaw/defaults/main.yml
+++ b/roles/openclaw/defaults/main.yml
@@ -8,7 +8,7 @@ ci_test: false
 # WARNING: Tasks using tailscale_authkey MUST set no_log: true to prevent credential exposure
 tailscale_enabled: false  # Set to true to install and configure Tailscale
 tailscale_authkey: ""  # Optional: set to auto-connect during installation
-tailscale_ssh: true  # Enable Tailscale SSH (tailscale up --ssh) when joining the tailnet
+tailscale_ssh: false  # Enable Tailscale SSH (tailscale up --ssh) when joining the tailnet; opt-in
 
 # Node.js version
 nodejs_version: "22.x"

--- a/roles/openclaw/tasks/tailscale-linux.yml
+++ b/roles/openclaw/tasks/tailscale-linux.yml
@@ -44,7 +44,26 @@
   changed_when: false
   failed_when: false
 
-- name: Display Tailscale auth URL if not connected (Linux)
+# `tailscale status --json` exits 0 whenever tailscaled is reachable, even in
+# NeedsLogin/Stopped states, so the exit code alone can't tell us if the node
+# is joined. Parse BackendState instead.
+- name: Determine whether Tailscale is connected (Linux)
+  ansible.builtin.set_fact:
+    tailscale_connected: >-
+      {{ tailscale_status_linux.rc == 0
+         and tailscale_status_linux.stdout | length > 0
+         and (tailscale_status_linux.stdout | from_json).BackendState == 'Running' }}
+
+- name: Join Tailnet with auth key (Linux)
+  ansible.builtin.command:
+    cmd: "tailscale up --authkey {{ tailscale_authkey }}"
+  when:
+    - not tailscale_connected
+    - tailscale_authkey | length > 0
+  no_log: true
+  changed_when: true
+
+- name: Display Tailscale auth URL if not connected and no auth key provided (Linux)
   ansible.builtin.debug:
     msg:
       - "============================================"
@@ -58,4 +77,6 @@
       - "sudo tailscale up --authkey tskey-auth-xxxxx"
       - ""
       - "Get auth key from: https://login.tailscale.com/admin/settings/keys"
-  when: tailscale_status_linux.rc != 0
+  when:
+    - not tailscale_connected
+    - tailscale_authkey | length == 0

--- a/roles/openclaw/tasks/tailscale-linux.yml
+++ b/roles/openclaw/tasks/tailscale-linux.yml
@@ -56,7 +56,7 @@
 
 - name: Join Tailnet with auth key (Linux)
   ansible.builtin.command:
-    cmd: "tailscale up --authkey {{ tailscale_authkey }}"
+    cmd: "tailscale up{% if tailscale_ssh | bool %} --ssh{% endif %} --authkey {{ tailscale_authkey }}"
   when:
     - not tailscale_connected
     - tailscale_authkey | length > 0

--- a/roles/openclaw/tasks/tailscale-linux.yml
+++ b/roles/openclaw/tasks/tailscale-linux.yml
@@ -47,20 +47,33 @@
 # `tailscale status --json` exits 0 whenever tailscaled is reachable, even in
 # NeedsLogin/Stopped states, so the exit code alone can't tell us if the node
 # is joined. Parse BackendState instead.
+- name: Determine Tailscale backend state (Linux)
+  ansible.builtin.set_fact:
+    tailscale_backend_state: >-
+      {{ (tailscale_status_linux.stdout | from_json).BackendState
+         if (tailscale_status_linux.rc == 0 and tailscale_status_linux.stdout | length > 0)
+         else 'Unknown' }}
+
 - name: Determine whether Tailscale is connected (Linux)
   ansible.builtin.set_fact:
-    tailscale_connected: >-
-      {{ tailscale_status_linux.rc == 0
-         and tailscale_status_linux.stdout | length > 0
-         and (tailscale_status_linux.stdout | from_json).BackendState == 'Running' }}
+    tailscale_connected: "{{ tailscale_backend_state == 'Running' }}"
 
 - name: Join Tailnet with auth key (Linux)
   ansible.builtin.command:
     cmd: "tailscale up{% if tailscale_ssh | bool %} --ssh{% endif %} --authkey {{ tailscale_authkey }}"
   when:
-    - not tailscale_connected
+    - tailscale_backend_state == 'NeedsLogin'
     - tailscale_authkey | length > 0
   no_log: true
+  changed_when: true
+
+# A `Stopped` node is already authorized; reconnect it without an auth key so
+# a routine re-run can't fail because a one-time/expired key was reused.
+- name: Reconnect previously authorized Tailscale node (Linux)
+  ansible.builtin.command:
+    cmd: "tailscale up{% if tailscale_ssh | bool %} --ssh{% endif %}"
+  when:
+    - tailscale_backend_state == 'Stopped'
   changed_when: true
 
 - name: Display Tailscale auth URL if not connected and no auth key provided (Linux)
@@ -78,5 +91,5 @@
       - ""
       - "Get auth key from: https://login.tailscale.com/admin/settings/keys"
   when:
-    - not tailscale_connected
+    - tailscale_backend_state == 'NeedsLogin'
     - tailscale_authkey | length == 0

--- a/roles/openclaw/tasks/tailscale-linux.yml
+++ b/roles/openclaw/tasks/tailscale-linux.yml
@@ -60,7 +60,7 @@
 
 - name: Join Tailnet with auth key (Linux)
   ansible.builtin.command:
-    cmd: "tailscale up{% if tailscale_ssh | bool %} --ssh{% endif %} --authkey {{ tailscale_authkey }}"
+    cmd: "tailscale up --reset{% if tailscale_ssh | bool %} --ssh{% endif %} --authkey {{ tailscale_authkey }}"
   when:
     - tailscale_backend_state == 'NeedsLogin'
     - tailscale_authkey | length > 0
@@ -69,9 +69,12 @@
 
 # A `Stopped` node is already authorized; reconnect it without an auth key so
 # a routine re-run can't fail because a one-time/expired key was reused.
+# `--reset` clears any non-default prefs left over from a previous run (e.g.
+# a prior tailscale_ssh value), since `tailscale up` otherwise refuses to
+# apply flags that don't restate every currently-active non-default pref.
 - name: Reconnect previously authorized Tailscale node (Linux)
   ansible.builtin.command:
-    cmd: "tailscale up{% if tailscale_ssh | bool %} --ssh{% endif %}"
+    cmd: "tailscale up --reset{% if tailscale_ssh | bool %} --ssh{% endif %}"
   when:
     - tailscale_backend_state == 'Stopped'
   changed_when: true


### PR DESCRIPTION
Closes #53

## Problem

`roles/openclaw/tasks/tailscale-linux.yml` derives connection state from the exit code of `tailscale status --json`. That command exits `0` whenever `tailscaled` is reachable — including the `NeedsLogin`/`Stopped` states — because the `--json` path returns before the state checks. Since the previous task starts `tailscaled`, `rc != 0` is effectively never true.

As a result:

- `tailscale_authkey` (documented in `defaults/main.yml` as *"set to auto-connect during installation"*) was never consumed by any task — unattended joins never happened.
- The "not connected yet" info message, gated on `rc != 0`, never displayed either.

## Change

- Parse the daemon's `BackendState` from `tailscale status --json` into a `tailscale_backend_state` fact instead of trusting the exit code, and derive `tailscale_connected` from it (`true` only when `== "Running"`).
- Add a **Join** task that runs `tailscale up --reset --authkey ...` only when `tailscale_backend_state == "NeedsLogin"` and an auth key is provided (`no_log: true` to keep the key out of logs).
- Add a separate **Reconnect** task for `tailscale_backend_state == "Stopped"`: an already-authorized node is brought back with `tailscale up --reset`, without consuming/needing an auth key. This avoids rejoining-with-authkey on every non-`Running` state, which could fail a routine re-run once a one-time/expired key is reused.
- Both commands use `--reset`: live testing showed `tailscale up` refuses to apply flags that don't restate *every* currently-active non-default pref, so a node that previously joined with a different `tailscale_ssh` value (or any other manually-set pref) would fail to reconnect/rejoin without it.
- Gate the informational "not connected yet" message on `tailscale_backend_state == "NeedsLogin"` with no auth key supplied.
- Add a `tailscale_ssh` variable (default `false`, **opt-in**) that passes `--ssh` to `tailscale up` so the node accepts Tailscale SSH per the tailnet ACLs on join. Documented in `README.md` and `docs/configuration.md`.

## Review history

An automated ClawSweeper review flagged two issues on a previous revision, both addressed above:
- `tailscale_ssh` defaulting to `true` silently expanded the host's remote-access surface for every auth-key join — now defaults to `false`.
- The join task reused `--authkey` for any non-`Running` state, including `Stopped` (already-authorized) nodes — now `Stopped` reconnects without an auth key, reserved for `NeedsLogin` only.

## Testing

`ansible-lint` (production profile, 0 failures) and `ansible-playbook --syntax-check` both pass.

Live-behavior verified end-to-end by running the actual `tailscale-linux.yml` tasks (via `ansible-playbook` + the `community.docker.docker` connection) against a disposable, privileged, systemd-enabled Ubuntu 24.04 Podman container, joined to a throwaway self-hosted [Headscale](https://github.com/juanfont/headscale) instance standing in for Tailscale's real coordination server (no real Tailscale account or secret involved — the "auth key" below is a locally-generated Headscale preauth key, valid only inside the disposable test network, already destroyed). `controlplane.tailscale.com` was pointed at the local Headscale via a container-local `/etc/hosts` entry + a CA trusted only inside that container, so every command below is the **exact, unmodified** command the role runs — nothing was passed to make it "test aware".

<details>
<summary>Redacted transcript (click to expand)</summary>

```
=== Fresh node, tailscaled never contacted a control server ===
$ tailscale status --json | jq .BackendState
"NeedsLogin"

=== 1. NeedsLogin, no tailscale_authkey -> info task fires, no join attempted ===
TASK [Join Tailnet with auth key (Linux)] ***** skipping
TASK [Reconnect previously authorized Tailscale node (Linux)] ***** skipping
TASK [Display Tailscale auth URL if not connected and no auth key provided (Linux)] *****
ok: [tailscale_test] => {
    "msg": [
        "============================================",
        "Tailscale installed but not connected yet",
        "============================================",
        "",
        "To connect this machine to your Tailnet:",
        "Run: sudo tailscale up",
        "",
        "For unattended installation, use an auth key:",
        "sudo tailscale up --authkey tskey-auth-xxxxx",
        "",
        "Get auth key from: https://login.tailscale.com/admin/settings/keys"
    ]
}
PLAY RECAP: ok=11  changed=0  failed=0  skipped=2

=== 2. NeedsLogin + tailscale_authkey=<redacted> -> Join task fires ===
TASK [Join Tailnet with auth key (Linux)] ***** changed: [tailscale_test]
TASK [Reconnect previously authorized Tailscale node (Linux)] ***** skipping
TASK [Display Tailscale auth URL ...] ***** skipping
PLAY RECAP: ok=11  changed=1  failed=0  skipped=2

$ tailscale status --json | jq '{BackendState, TailscaleIPs}'
{
  "BackendState": "Running",
  "TailscaleIPs": ["100.64.0.2", "fd7a:115c:a1e0::2"]
}

=== 3. Running -> idempotent re-run, both join/reconnect tasks skip ===
TASK [Join Tailnet with auth key (Linux)] ***** skipping
TASK [Reconnect previously authorized Tailscale node (Linux)] ***** skipping
TASK [Display Tailscale auth URL ...] ***** skipping
PLAY RECAP: ok=10  changed=0  failed=0  skipped=3

=== 4. tailscale down -> Stopped, no authkey -> Reconnect task fires (no key needed) ===
$ tailscale status --json | jq .BackendState
"Stopped"

TASK [Join Tailnet with auth key (Linux)] ***** skipping
TASK [Reconnect previously authorized Tailscale node (Linux)] ***** changed: [tailscale_test]
TASK [Display Tailscale auth URL ...] ***** skipping
PLAY RECAP: ok=11  changed=1  failed=0  skipped=2

$ tailscale status --json | jq .BackendState
"Running"

=== 5. tailscale down again, tailscale_ssh: true -> Reconnect applies --ssh ===
TASK [Reconnect previously authorized Tailscale node (Linux)] ***** changed: [tailscale_test]
PLAY RECAP: ok=11  changed=1  failed=0  skipped=2

$ tailscale status --json | jq .BackendState
"Running"
$ tailscale debug prefs | jq .RunSSH
true

=== 6. Idempotent re-run, tailscale_ssh: true, already Running -> changed=0 ===
TASK [Join Tailnet with auth key (Linux)] ***** skipping
TASK [Reconnect previously authorized Tailscale node (Linux)] ***** skipping
TASK [Display Tailscale auth URL ...] ***** skipping
PLAY RECAP: ok=10  changed=0  failed=0  skipped=3
```

Also caught by this testing: without `--reset`, step 5 failed with `tailscale up requires mentioning all non-default flags` once the node had any prior non-default pref — the reason `--reset` was added to both commands (see Change section).

</details>

## Note

Tailscale SSH also requires the tailnet ACLs to permit SSH to the node (a `ssh` rule / appropriate tags). This PR only adds the `--ssh` flag on the client side, and it stays off by default.
