### PR TITLE
feat(config): add MiniMax AI provider with regional endpoints

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -59,8 +59,8 @@ sudo nano /home/openclaw/.openclaw/config.yml
 # Key settings to configure:
 # - provider: whatsapp/telegram/signal
 # - phone: your number
-# - ai.provider: anthropic/openai
-# - ai.model: claude-3-5-sonnet-20241022
+# - ai.provider: anthropic/openai/minimax
+# - ai.model: claude-3-5-sonnet-20241022 / MiniMax-M3 / MiniMax-M2.7
 ```
 
 ### 3. Login to Provider

--- a/roles/openclaw/templates/openclaw-config.yml.j2
+++ b/roles/openclaw/templates/openclaw-config.yml.j2
@@ -24,18 +24,41 @@ signal:
 
 # AI Model Configuration
 ai:
-  # Model provider: anthropic, openai
+  # Model provider: anthropic, openai, minimax
   provider: anthropic
 
   # API Keys (set as environment variables or here)
   # anthropic_api_key: ""
   # openai_api_key: ""
+  # minimax_api_key: ""
 
   # Model selection
   model: claude-3-5-sonnet-20241022
+  # MiniMax models: MiniMax-M3, MiniMax-M2.7
+  # model: MiniMax-M3
 
   # Max tokens per response
   max_tokens: 4096
+
+# MiniMax Provider Configuration (if using ai.provider: minimax)
+# MiniMax exposes both OpenAI- and Anthropic-compatible endpoints, with a
+# global (api.minimax.io) and a China (api.minimaxi.com) region.
+minimax:
+  # Regional endpoints: global_en or cn_zh
+  region: global_en
+
+  # Base URLs per region (defaults shown for global_en)
+  # global_en:
+  #   openai_base_url: https://api.minimax.io/v1
+  #   anthropic_base_url: https://api.minimax.io/anthropic
+  # cn_zh:
+  #   openai_base_url: https://api.minimaxi.com/v1
+  #   anthropic_base_url: https://api.minimaxi.com/anthropic
+  openai_base_url: https://api.minimax.io/v1
+  anthropic_base_url: https://api.minimax.io/anthropic
+
+  # Model context window (tokens)
+  context_window: 1000000
 
 # Gateway Settings
 gateway:


### PR DESCRIPTION
Reason: provider-add — add the MiniMax AI provider, current model IDs, and regional endpoints to the generated OpenClaw configuration.

## Changes

- `roles/openclaw/templates/openclaw-config.yml.j2`: add `minimax` to the documented `ai.provider` options, document the `minimax_api_key`, list the current `MiniMax-M3` and `MiniMax-M2.7` model IDs, and add a `minimax` configuration block with the global (`api.minimax.io`) and China (`api.minimaxi.com`) regional endpoints for both the OpenAI- and Anthropic-compatible base URLs, plus the 1,000,000-token context window.
- `docs/installation.md`: update the key-settings comment to include `minimax` as an `ai.provider` option and the MiniMax model IDs.

## Checks

- Verified the rendered template is valid YAML structure and contains no tabs (node sanity check).
- Secret scan against the diff: clean.
