### PR TITLE
fix: validate standalone deployment playbook in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -46,7 +46,7 @@ jobs:
         run: ansible-galaxy collection install -r requirements.yml
 
       - name: Run ansible-lint
-        run: ansible-lint playbook.yml tests/docker-group-security.yml
+        run: ansible-lint playbook.yml playbooks/*.yml tests/docker-group-security.yml
 
   syntax-check:
     name: Ansible Syntax Check
@@ -69,6 +69,8 @@ jobs:
       - name: Ansible syntax check
         run: |
           ansible-playbook playbook.yml --syntax-check
+          ansible-playbook playbooks/install.yml --syntax-check
+          ansible-playbook playbooks/deploy.yml --syntax-check
           ansible-playbook tests/docker-group-security.yml --syntax-check
 
   docker-group-security:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Ansible playbook for automated, hardened OpenClaw installation on Debian/Ubuntu 
 
 ## Key Principles
 
-1. **Security First**: Firewall must be configured before Docker installation
+1. **Security First**: Install Docker before configuring its firewall isolation
 2. **One Command Install**: `curl | bash` should work out of the box
 3. **Localhost Only**: All container ports bind to 127.0.0.1
 4. **Defense in Depth**: UFW + DOCKER-USER + localhost binding + non-root container
@@ -18,15 +18,17 @@ Docker must be installed **before** firewall configuration.
 
 Task order in `roles/openclaw/tasks/main.yml`:
 ```yaml
-- tailscale.yml  # VPN setup
-- user.yml       # Create system user
-- docker.yml     # Install Docker (creates /etc/docker)
-- firewall.yml   # Configure UFW + daemon.json (needs /etc/docker to exist)
-- nodejs.yml     # Node.js + pnpm
-- openclaw.yml   # Container setup
+- system-tools.yml     # Base system packages
+- tailscale-linux.yml  # VPN setup (when enabled)
+- user.yml             # Create system user
+- docker-linux.yml     # Install Docker and include docker-security.yml
+- firewall-linux.yml   # Configure UFW + daemon.json (needs /etc/docker to exist)
+- nodejs.yml           # Node.js + pnpm
+- openclaw.yml         # OpenClaw setup
 ```
 
-Reason: `firewall.yml` writes `/etc/docker/daemon.json` and restarts Docker service.
+Reason: `firewall-linux.yml` writes `/etc/docker/daemon.json` and restarts Docker service.
+`docker-security.yml` is nested under `docker-linux.yml`, not included directly from `main.yml`.
 
 ### DOCKER-USER Chain
 Located in `/etc/ufw/after.rules`. Uses dynamic interface detection (not hardcoded `eth0`).
@@ -86,7 +88,7 @@ curl http://localhost:80        # Should work
 
 ## Common Mistakes to Avoid
 
-1. ❌ Installing Docker before configuring firewall
+1. ❌ Configuring the firewall before installing Docker
 2. ❌ Using `0.0.0.0` port binding
 3. ❌ Hardcoding network interface names (use dynamic detection)
 4. ❌ Setting `iptables: false` in Docker daemon


### PR DESCRIPTION
Closes #61

## What Problem This Solves

Fixes an issue where maintainers could change the supported standalone deployment playbook without Ansible-specific lint or syntax validation. Contributor guidance also named task files that no longer exist and contradicted the required Docker-before-firewall order.

## Why This Change Was Made

CI now lints every supported playbook and syntax-checks both installation entry points explicitly. The task-order guidance now matches the active include graph, including the nested Docker security tasks, while preserving the requirement that Docker installation precede firewall configuration.

## User Impact

Maintainers receive CI feedback for changes to `playbooks/deploy.yml`, and contributors have accurate task-order guidance. There is no runtime behavior change.

## Evidence

Before this change, the Ansible-specific workflow named only `playbook.yml` and `tests/docker-group-security.yml`; `playbooks/deploy.yml` was not linted or syntax-checked.

Validated after the change:

```bash
yamllint .
ansible-lint playbook.yml playbooks/*.yml tests/docker-group-security.yml
ansible-playbook playbook.yml --syntax-check
ansible-playbook playbooks/install.yml --syntax-check
ansible-playbook playbooks/deploy.yml --syntax-check
ansible-playbook tests/docker-group-security.yml --syntax-check
```

Terminal transcript from the patched branch:

```text
$ yamllint .
# exit 0; no output

$ ansible-lint playbook.yml playbooks/*.yml tests/docker-group-security.yml
Passed: 0 failure(s), 0 warning(s) on 4 files. Profile 'production' was required, and it passed.

$ ansible-playbook playbook.yml --syntax-check
playbook: playbook.yml

$ ansible-playbook playbooks/install.yml --syntax-check
playbook: playbooks/install.yml

$ ansible-playbook playbooks/deploy.yml --syntax-check
playbook: playbooks/deploy.yml

$ ansible-playbook tests/docker-group-security.yml --syntax-check
playbook: tests/docker-group-security.yml
```

All commands exited successfully. The syntax checks also emitted the expected empty-inventory warnings; the deployment check additionally reported that the local empty inventory did not match `openclaw_servers`.

Disclosure: AI was used to understand the codebase and review the fix.
