### PR TITLE
fix(ci): restrict lint workflow permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches: [main, development]
 
+permissions:
+  contents: read
+
 jobs:
   yaml-lint:
     name: YAML Lint


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the lint workflow's four jobs inherited repository-level `GITHUB_TOKEN` permissions instead of declaring the read-only access they require.

CodeQL alerts:
- https://github.com/openclaw/openclaw-ansible/security/code-scanning/1
- https://github.com/openclaw/openclaw-ansible/security/code-scanning/2
- https://github.com/openclaw/openclaw-ansible/security/code-scanning/3
- https://github.com/openclaw/openclaw-ansible/security/code-scanning/4

## Why This Change Was Made

The workflow now grants `contents: read` once at the workflow boundary. All four jobs only check out and inspect repository content, so no write permissions or job-specific exceptions are needed.

## User Impact

No user-visible behavior changes. The lint workflow keeps its existing behavior with a least-privilege token.

## Evidence

- `actionlint .github/workflows/lint.yml`
- `yamllint .github/workflows/lint.yml`
- Ruby safe YAML parse
- `git diff --check`
