### PR TITLE
chore(deps): refresh Ansible tooling and CI actions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.ansible
+venv
+*.tar.gz

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,12 +16,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: '3.11'
+          python-version: '3.14'
 
       - name: Install lint dependencies
         run: python -m pip install -r requirements-lint.txt
@@ -34,12 +34,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: '3.11'
+          python-version: '3.14'
 
       - name: Install dependencies
         run: |
@@ -56,12 +56,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: '3.11'
+          python-version: '3.14'
 
       - name: Install Ansible
         run: python -m pip install -r requirements-lint.txt
@@ -79,12 +79,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: '3.11'
+          python-version: '3.14'
 
       - name: Install Ansible
         run: python -m pip install -r requirements-lint.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Update the Ansible lint toolchain and GitHub Actions dependencies, with Python 3.14 for CI.
+- Exclude checkout metadata and local Ansible caches from Docker test images so the harness also works from Git worktrees.
+- Preserve service-user privilege switching in the Docker test harness to avoid recurring pnpm ownership changes.
 - Remove the OpenClaw service user from the root-equivalent Docker group, including on existing installations. Thanks @Tonynanra for the report.
 - Document expected results for post-install security verification and link the checks from setup documentation. Thanks @justinfiore for the report.
 

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -1,3 +1,3 @@
-ansible-core==2.16.19
-ansible-lint==6.22.2
-yamllint==1.37.1
+ansible-core==2.21.3
+ansible-lint==26.8.0
+yamllint==1.38.0

--- a/tests/README.md
+++ b/tests/README.md
@@ -33,9 +33,8 @@ The `ci_test` variable skips tasks that require:
 - Docker-in-Docker (Docker CE installation)
 - Kernel access (UFW/iptables firewall)
 - systemd services (loginctl, daemon installation)
-- External package installation (openclaw app install)
 
-Everything else runs normally: package installation, user creation, Node.js/pnpm setup, directory structure, config file rendering, etc.
+Everything else runs normally: package installation, user creation, Node.js/pnpm setup, OpenClaw installation from npm, directory structure, config file rendering, etc. The harness requires internet access.
 
 ## What Gets Tested
 
@@ -51,7 +50,7 @@ Everything else runs normally: package installation, user creation, Node.js/pnpm
 | UFW / iptables | ❌ No | Needs kernel access |
 | fail2ban / systemd | ❌ No | Needs running systemd |
 | Tailscale | ❌ No | Disabled by default already |
-| OpenClaw app install | ❌ No | External package |
+| OpenClaw app install | ✅ Yes | Latest npm release and version check |
 | Idempotency | ✅ Yes | Second run must have 0 changes |
 
 ## Exit Codes
@@ -60,6 +59,21 @@ Everything else runs normally: package installation, user creation, Node.js/pnpm
 - `1` - Test failure (convergence failed, verification failed, or idempotency check failed)
 
 ## Development
+
+### Lint and Syntax Checks
+
+The pinned lint tools in `requirements-lint.txt` require Python 3.12 or newer; CI uses Python 3.14. These development tools do not change the installer's minimum Ansible version.
+
+```bash
+python -m pip install -r requirements-lint.txt
+ansible-galaxy collection install -r requirements.yml
+yamllint .
+ansible-lint playbook.yml tests/docker-group-security.yml
+ansible-playbook playbook.yml --syntax-check
+ansible-playbook tests/docker-group-security.yml --syntax-check
+```
+
+### Additional Distributions
 
 To add tests for additional distributions:
 1. Create `Dockerfile.<distro>` (e.g., `Dockerfile.debian12`)

--- a/tests/entrypoint.sh
+++ b/tests/entrypoint.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-PLAYBOOK_ARGS=(-e ci_test=true -e ansible_become=false --connection=local)
+# Keep task-level become_user active so pnpm runs as the service user, not root.
+PLAYBOOK_ARGS=(-e ci_test=true --connection=local)
 
 # --- Step 1: Convergence ---
 echo "===> Step 1: Convergence test"


### PR DESCRIPTION
The CI toolchain was pinned to older Ansible and GitHub Actions releases. This updates the development dependencies while keeping the installer's supported Ansible minimum and production runtime defaults unchanged.

Updates:

- Python lint tools: ansible-core 2.16.19 → 2.21.3, ansible-lint 6.22.2 → 26.8.0, yamllint 1.37.1 → 1.38.0.
- GitHub Actions: checkout v4 → v7.0.1 and setup-python v5 → v7.0.0, both pinned to their release commit SHAs. CI Python moves from 3.11 to 3.14; the current Ansible Core requires Python 3.12 or newer.
- The existing Galaxy ranges already accept community.docker 5.2.2, community.general 13.3.0, and ansible.posix 2.2.2; these current versions were installed and tested. The dispatch token action is already current at v3.2.0.

Running the complete Docker harness exposed two test-environment problems. The image copied the linked worktree's `.git` pointer, making Git commands inside the container fail against a host-only path. The harness also globally disabled privilege switching, overriding the tasks that install pnpm/OpenClaw as the service user and causing recurring ownership repairs. A `.dockerignore` and removal of that global override fix these issues without changing the production role. The testing guide now accurately states that the harness installs OpenClaw from npm.

Held upgrade: Node.js 22.x → 26.x. The NodeSource task preserves an existing repository file with `creates`, so changing the default alone would not migrate existing installations. A major runtime upgrade also needs validation across the supported distributions. Node.js 22.23.2 with pnpm 11.24.0 and the npm-selected OpenClaw release passed the integration tests.

Validation:

- Baseline `main` CI was green: Lint, ClawSweeper Dispatch, and Scheduled. No open Dependabot or Renovate PRs were superseded.
- Python 3.14 installation and dependency compatibility check: 29 packages compatible.
- ansible-lint production profile: 17 files, 0 failures, 0 warnings. yamllint and actionlint passed.
- Four Ansible syntax checks, six Bash syntax checks, and the Ansible collection build passed.
- Ubuntu 24.04 / Ansible Core 2.21.3: Docker-group security regression 11 successful tasks; fresh convergence 54 tasks; verification 13 tasks; idempotency 52 tasks with `changed=0`. All had 0 failures. Check mode completed with 43 successful tasks, 1 predicted change, and 0 failures.
- Ubuntu's Ansible Core 2.16.3: the corrected harness passed convergence, verification, and idempotency, with 52/13/52 successful tasks and `changed=0` on both installation passes.
- OpenClaw's installed binary was exercised through its version check. The container tests do not validate firewall rules, a running systemd daemon, or external network isolation; no privileged VM/network scan was performed.
- Codex autoreview completed with no actionable findings at its configured blocking threshold.

The latest Ansible emits deprecation warnings about injected top-level facts, scheduled for removal in Core 2.24. Migrating fact access is outside this dependency update; it does not fail the tested releases.
