### PR TITLE
fix(tailscale): safely join with auth keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Edit `roles/openclaw/defaults/main.yml` before running the playbook.
 | `openclaw_repo_url` | `https://github.com/openclaw/openclaw.git` | Git repository (dev mode) |
 | `openclaw_repo_branch` | `main` | Git branch (dev mode) |
 | `tailscale_authkey` | `""` | Tailscale auth key for auto-connect |
+| `tailscale_ssh` | `false` | Enable Tailscale SSH when joining with an auth key |
 | `nodejs_version` | `22.x` | Node.js version to install |
 
 See [`roles/openclaw/defaults/main.yml`](roles/openclaw/defaults/main.yml) for the complete list.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -179,6 +179,19 @@ These variables only apply when `openclaw_install_mode: development`
   ```
 - **Get Key**: https://login.tailscale.com/admin/settings/keys
 
+Providing a non-empty auth key enables Tailscale installation automatically;
+`tailscale_enabled: true` is only required for interactive/manual setup.
+
+#### `tailscale_ssh`
+- **Type**: Boolean
+- **Default**: `false`
+- **Description**: Enable Tailscale SSH when joining with an auth key. This is
+  opt-in and still requires an appropriate tailnet SSH policy.
+- **Example**:
+  ```bash
+  -e tailscale_ssh=true
+  ```
+
 ### OS-Specific Settings
 
 These are automatically set based on the detected OS:

--- a/roles/openclaw/defaults/main.yml
+++ b/roles/openclaw/defaults/main.yml
@@ -8,6 +8,8 @@ ci_test: false
 # WARNING: Tasks using tailscale_authkey MUST set no_log: true to prevent credential exposure
 tailscale_enabled: false  # Set to true to install and configure Tailscale
 tailscale_authkey: ""  # Optional: set to auto-connect during installation
+tailscale_authkey_timeout: "60s"  # Bound unattended joins; Tailscale otherwise waits forever
+tailscale_ssh: false  # Opt in to Tailscale SSH when joining with an auth key
 
 # Node.js version
 nodejs_version: "22.x"

--- a/roles/openclaw/tasks/firewall-linux.yml
+++ b/roles/openclaw/tasks/firewall-linux.yml
@@ -103,7 +103,7 @@
     port: '41641'
     proto: udp
     comment: 'Tailscale'
-  when: tailscale_enabled | bool
+  when: tailscale_enabled | bool or tailscale_authkey | default('') | length > 0
 
 - name: Get default network interface
   ansible.builtin.shell:

--- a/roles/openclaw/tasks/main.yml
+++ b/roles/openclaw/tasks/main.yml
@@ -4,7 +4,7 @@
 
 - name: Include Tailscale installation tasks
   ansible.builtin.include_tasks: tailscale-linux.yml
-  when: tailscale_enabled | bool
+  when: tailscale_enabled | bool or tailscale_authkey | default('') | length > 0
 
 - name: Include user creation tasks
   ansible.builtin.include_tasks: user.yml

--- a/roles/openclaw/tasks/tailscale-linux.yml
+++ b/roles/openclaw/tasks/tailscale-linux.yml
@@ -44,7 +44,64 @@
   changed_when: false
   failed_when: false
 
-- name: Display Tailscale auth URL if not connected (Linux)
+- name: Default Tailscale backend state when status is unavailable
+  ansible.builtin.set_fact:
+    tailscale_backend_state: "Unknown"
+
+# `tailscale status --json` exits 0 whenever tailscaled is reachable, including
+# NeedsLogin and Stopped. Parse BackendState instead of treating rc=0 as joined.
+- name: Parse Tailscale backend state
+  when:
+    - tailscale_status_linux.rc == 0
+    - tailscale_status_linux.stdout | default('') | trim | length > 0
+  block:
+    - name: Read BackendState from Tailscale status JSON
+      ansible.builtin.set_fact:
+        tailscale_backend_state: >-
+          {{ (tailscale_status_linux.stdout | from_json).BackendState
+             | default('Unknown') }}
+  rescue:
+    - name: Report unreadable Tailscale status
+      ansible.builtin.debug:
+        msg: >-
+          Tailscale returned unreadable status JSON. Automatic login is being
+          skipped; inspect `sudo tailscale status` before retrying.
+
+# Only authenticate a fresh NeedsLogin node. A Stopped node is already
+# authorized and can carry operator-managed preferences; this role must not
+# reset or silently replace those preferences during a routine rerun.
+- name: Join Tailnet with auth key (Linux)
+  ansible.builtin.command:
+    argv: >-
+      {{
+        [
+          'tailscale',
+          'up',
+          '--auth-key=' ~ tailscale_authkey,
+          '--timeout=' ~ tailscale_authkey_timeout
+        ]
+        + (['--ssh'] if tailscale_ssh | bool else [])
+      }}
+  register: tailscale_join
+  changed_when: tailscale_join.rc == 0
+  failed_when: false
+  no_log: true
+  when:
+    - tailscale_backend_state == 'NeedsLogin'
+    - tailscale_authkey | default('') | length > 0
+
+- name: Fail clearly when Tailscale auth-key join fails
+  ansible.builtin.fail:
+    msg: >-
+      Tailscale could not join the tailnet within {{ tailscale_authkey_timeout }}.
+      Check control-plane reachability and auth-key validity, then rerun the
+      playbook or connect manually with `sudo tailscale up`.
+  when:
+    - tailscale_join is defined
+    - not (tailscale_join.skipped | default(false))
+    - (tailscale_join.rc | default(1)) != 0
+
+- name: Display Tailscale auth URL when login is required (Linux)
   ansible.builtin.debug:
     msg:
       - "============================================"
@@ -58,4 +115,20 @@
       - "sudo tailscale up --authkey tskey-auth-xxxxx"
       - ""
       - "Get auth key from: https://login.tailscale.com/admin/settings/keys"
-  when: tailscale_status_linux.rc != 0
+  when:
+    - tailscale_backend_state == 'NeedsLogin'
+    - tailscale_authkey | default('') | length == 0
+
+- name: Display guidance for a stopped Tailscale node (Linux)
+  ansible.builtin.debug:
+    msg: >-
+      Tailscale is authorized but stopped. Existing Tailscale preferences were
+      preserved. Reconnect deliberately with `sudo tailscale up`.
+  when: tailscale_backend_state == 'Stopped'
+
+- name: Display guidance when Tailscale status is unavailable (Linux)
+  ansible.builtin.debug:
+    msg: >-
+      Tailscale status is unavailable, so automatic login was skipped. Run
+      `sudo tailscale status` and inspect the tailscaled service before retrying.
+  when: tailscale_backend_state == 'Unknown'


### PR DESCRIPTION
Supersedes #54 with a current-main implementation while preserving Jens's authorship in the commit.

## What this incorporates

- Uses Tailscale `BackendState` instead of the misleading `status --json` exit code.
- Makes a supplied auth key activate Tailscale, matching the existing README examples.
- Joins only a fresh `NeedsLogin` node and never resets existing preferences.
- Leaves an already-authorized `Stopped` node for deliberate operator recovery.
- Keeps Tailscale SSH opt-in and bounds unattended login time.
- Handles unreadable or unavailable status with actionable guidance.

This deliberately does not use `tailscale up --reset`: routine Ansible runs should not clear user-managed DNS, routing, exit-node, SSH, or other preferences.

## Verification

- `yamllint .`
- `ansible-lint playbook.yml playbooks/*.yml tests/docker-group-security.yml`
- syntax checks for `playbook.yml`, `playbooks/install.yml`, and `playbooks/deploy.yml`

Thank you @jabbrwcky for the first contribution to this repository and for identifying the underlying `BackendState` bug.
