### PR TITLE
feat(tailscale): make operator access explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,7 @@ Edit `roles/openclaw/defaults/main.yml` before running the playbook.
 | `openclaw_repo_url` | `https://github.com/openclaw/openclaw.git` | Git repository (dev mode) |
 | `openclaw_repo_branch` | `main` | Git branch (dev mode) |
 | `tailscale_authkey` | `""` | Tailscale auth key for auto-connect |
+| `tailscale_operator_enabled` | `false` | Let the openclaw user manage Tailscale and Serve |
 | `nodejs_version` | `22.x` | Node.js version to install |
 
 See [`roles/openclaw/defaults/main.yml`](roles/openclaw/defaults/main.yml) for the complete list.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -179,6 +179,18 @@ These variables only apply when `openclaw_install_mode: development`
   ```
 - **Get Key**: https://login.tailscale.com/admin/settings/keys
 
+#### `tailscale_operator_enabled`
+- **Type**: Boolean
+- **Default**: `false`
+- **Description**: Delegate Tailscale operator access to the OpenClaw service
+  account so it can manage Tailscale Serve without sudo. This grants broader
+  control of the local Tailscale daemon and is intentionally opt-in. The role
+  refuses to replace an operator already assigned to another account.
+- **Example**:
+  ```bash
+  -e tailscale_operator_enabled=true
+  ```
+
 ### OS-Specific Settings
 
 These are automatically set based on the detected OS:

--- a/roles/openclaw/defaults/main.yml
+++ b/roles/openclaw/defaults/main.yml
@@ -8,6 +8,7 @@ ci_test: false
 # WARNING: Tasks using tailscale_authkey MUST set no_log: true to prevent credential exposure
 tailscale_enabled: false  # Set to true to install and configure Tailscale
 tailscale_authkey: ""  # Optional: set to auto-connect during installation
+tailscale_operator_enabled: false  # Opt in to let openclaw manage Tailscale and Serve
 
 # Node.js version
 nodejs_version: "22.x"

--- a/roles/openclaw/tasks/firewall-linux.yml
+++ b/roles/openclaw/tasks/firewall-linux.yml
@@ -103,7 +103,7 @@
     port: '41641'
     proto: udp
     comment: 'Tailscale'
-  when: tailscale_enabled | bool
+  when: tailscale_enabled | bool or tailscale_operator_enabled | bool
 
 - name: Get default network interface
   ansible.builtin.shell:

--- a/roles/openclaw/tasks/main.yml
+++ b/roles/openclaw/tasks/main.yml
@@ -4,10 +4,51 @@
 
 - name: Include Tailscale installation tasks
   ansible.builtin.include_tasks: tailscale-linux.yml
-  when: tailscale_enabled | bool
+  when: tailscale_enabled | bool or tailscale_operator_enabled | bool
 
 - name: Include user creation tasks
   ansible.builtin.include_tasks: user.yml
+
+- name: Read the current Tailscale operator
+  ansible.builtin.command: tailscale get operator
+  register: tailscale_operator_current
+  changed_when: false
+  failed_when: false
+  when: tailscale_operator_enabled | bool
+
+- name: Fail safely when the current Tailscale operator cannot be read
+  ansible.builtin.fail:
+    msg: >-
+      Unable to read the current Tailscale operator. No permission was changed.
+      Verify `sudo tailscale get operator` before retrying.
+  when:
+    - tailscale_operator_enabled | bool
+    - (tailscale_operator_current.rc | default(1)) != 0
+
+- name: Refuse to replace an existing Tailscale operator
+  ansible.builtin.fail:
+    msg: >-
+      Tailscale already delegates operator access to
+      '{{ tailscale_operator_current.stdout | trim }}'. No permission was
+      changed. Remove that delegation explicitly before granting it to
+      '{{ openclaw_user }}'.
+  when:
+    - tailscale_operator_enabled | bool
+    - (tailscale_operator_current.rc | default(1)) == 0
+    - tailscale_operator_current.stdout | default('') | trim | length > 0
+    - tailscale_operator_current.stdout | default('') | trim != openclaw_user
+
+- name: Grant the openclaw user Tailscale operator access
+  ansible.builtin.command:
+    argv:
+      - tailscale
+      - set
+      - "--operator={{ openclaw_user }}"
+  changed_when: true
+  when:
+    - tailscale_operator_enabled | bool
+    - (tailscale_operator_current.rc | default(1)) == 0
+    - tailscale_operator_current.stdout | default('') | trim | length == 0
 
 - name: Include Docker installation tasks
   ansible.builtin.include_tasks: docker-linux.yml


### PR DESCRIPTION
Splits the Serve/operator portion of #52 into a focused current-main change while preserving Sebastien's authorship in the commit. Auth-key provisioning remains separate in the #54 replacement.

## What this incorporates

- Adds an explicit `tailscale_operator_enabled` opt-in.
- Installs Tailscale when operator access is requested.
- Uses the documented `tailscale get operator` interface.
- Refuses to overwrite an operator assigned to another local account.
- Grants the OpenClaw service account operator access only when no operator exists.
- Does not add broader sudoers entries or duplicate authentication logic.

The default remains least privilege. Enabling this setting intentionally lets the OpenClaw account manage the local Tailscale daemon and Tailscale Serve without sudo.

## Verification

- `yamllint .`
- `ansible-lint playbook.yml playbooks/*.yml tests/docker-group-security.yml`
- syntax checks for `playbook.yml`, `playbooks/install.yml`, and `playbooks/deploy.yml`

Thank you @SebTardif for the first contribution to this repository and for surfacing the Tailscale Serve permission gap.
