### PR TITLE
fix: service user can reconfigure Tailscale or read other journals via sudo

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,7 +49,7 @@ jobs:
         run: ansible-galaxy collection install -r requirements.yml
 
       - name: Run ansible-lint
-        run: ansible-lint playbook.yml tests/docker-group-security.yml
+        run: ansible-lint playbook.yml tests/docker-group-security.yml tests/sudoers-scope.yml
 
   syntax-check:
     name: Ansible Syntax Check
@@ -73,6 +73,7 @@ jobs:
         run: |
           ansible-playbook playbook.yml --syntax-check
           ansible-playbook tests/docker-group-security.yml --syntax-check
+          ansible-playbook tests/sudoers-scope.yml --syntax-check
 
   docker-group-security:
     name: Docker Group Security
@@ -102,3 +103,21 @@ jobs:
 
       - name: Verify installation, configuration, and idempotency
         run: bash tests/run-tests.sh
+
+  sudoers-scope:
+    name: Sudoers Scope
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: '3.14'
+
+      - name: Install Ansible
+        run: python -m pip install -r requirements-lint.txt
+
+      - name: Verify sudoers argument wildcards are pinned
+        run: ansible-playbook tests/sudoers-scope.yml

--- a/docs/security.md
+++ b/docs/security.md
@@ -90,8 +90,9 @@ The openclaw user has limited sudo permissions (not full root):
 # Allowed commands only:
 - systemctl start/stop/restart/status openclaw
 - systemctl daemon-reload
-- tailscale commands
-- journalctl for openclaw logs
+- tailscale status/down/version plus diagnostics
+- tailscale up with no extra flags (stored settings only)
+- journalctl -u openclaw with -f, -n 50, and --no-pager
 ```
 
 The user is deliberately excluded from the `docker` group. Membership would

--- a/roles/openclaw/tasks/user.yml
+++ b/roles/openclaw/tasks/user.yml
@@ -55,8 +55,8 @@
       # SECURITY NOTE: These permissions are intentionally limited.
       # If openclaw is compromised, attackers can only:
       # - Manage the openclaw service
-      # - Run basic tailscale diagnostics
-      # - View openclaw logs
+      # - Run basic tailscale diagnostics and stored-settings up/down
+      # - View openclaw unit logs
       #
       # To grant full tailscale control (e.g., for self-healing VPN):
       #   {{ openclaw_user }} ALL=(ALL) NOPASSWD: /usr/bin/tailscale *
@@ -74,19 +74,24 @@
       # daemon-reload affects all units (required after service file changes)
       {{ openclaw_user }} ALL=(ALL) NOPASSWD: /usr/bin/systemctl daemon-reload
 
-      # Tailscale - diagnostics + connect/disconnect
-      # NOTE: 'up' allows flags like --advertise-exit-node. For tighter control,
-      # remove 'up' and 'down' lines - operator must then manage VPN manually.
+      # Tailscale - diagnostics + stored-settings connect/disconnect
+      # 'up' is pinned with no extra flags. Exit-node, routes, authkey,
+      # and advertise-* stay root-only.
       {{ openclaw_user }} ALL=(ALL) NOPASSWD: /usr/bin/tailscale status
-      {{ openclaw_user }} ALL=(ALL) NOPASSWD: /usr/bin/tailscale up *
+      {{ openclaw_user }} ALL=(ALL) NOPASSWD: /usr/bin/tailscale up
       {{ openclaw_user }} ALL=(ALL) NOPASSWD: /usr/bin/tailscale down
       {{ openclaw_user }} ALL=(ALL) NOPASSWD: /usr/bin/tailscale ip *
       {{ openclaw_user }} ALL=(ALL) NOPASSWD: /usr/bin/tailscale version
       {{ openclaw_user }} ALL=(ALL) NOPASSWD: /usr/bin/tailscale ping *
       {{ openclaw_user }} ALL=(ALL) NOPASSWD: /usr/bin/tailscale whois *
 
-      # Journal access - openclaw logs only
-      {{ openclaw_user }} ALL=(ALL) NOPASSWD: /usr/bin/journalctl -u openclaw *
+      # Journal access - openclaw unit only (no extra -u/--directory/--file)
+      {{ openclaw_user }} ALL=(ALL) NOPASSWD: /usr/bin/journalctl -u openclaw
+      {{ openclaw_user }} ALL=(ALL) NOPASSWD: /usr/bin/journalctl -u openclaw -f
+      {{ openclaw_user }} ALL=(ALL) NOPASSWD: /usr/bin/journalctl -u openclaw -n 50
+      {{ openclaw_user }} ALL=(ALL) NOPASSWD: /usr/bin/journalctl -u openclaw --no-pager
+      {{ openclaw_user }} ALL=(ALL) NOPASSWD: /usr/bin/journalctl -u openclaw -n 50 --no-pager
+      {{ openclaw_user }} ALL=(ALL) NOPASSWD: /usr/bin/journalctl -u openclaw -f --no-pager
     validate: /usr/sbin/visudo -cf %s
 
 - name: Set openclaw user as primary user for installation

--- a/tests/README.md
+++ b/tests/README.md
@@ -44,6 +44,7 @@ Everything else runs normally: package installation, user creation, Node.js/pnpm
 |-----------|---------|-------|
 | System packages (35+) | ✅ Yes | Full apt install |
 | User creation + config | ✅ Yes | User, .bashrc, sudoers, SSH dir |
+| Sudoers argument pins | ✅ Yes | `tests/sudoers-scope.yml` rejects `tailscale up *` and `journalctl -u openclaw *` |
 | Node.js + pnpm | ✅ Yes | Full install + version check |
 | Directory structure | ✅ Yes | All .openclaw/* dirs with perms |
 | Git global config | ✅ Yes | Aliases, default branch |
@@ -70,9 +71,11 @@ The pinned lint tools in `requirements-lint.txt` require Python 3.12 or newer; C
 python -m pip install -r requirements-lint.txt
 ansible-galaxy collection install -r requirements.yml
 yamllint .
-ansible-lint playbook.yml tests/docker-group-security.yml
+ansible-lint playbook.yml tests/docker-group-security.yml tests/sudoers-scope.yml
 ansible-playbook playbook.yml --syntax-check
 ansible-playbook tests/docker-group-security.yml --syntax-check
+ansible-playbook tests/sudoers-scope.yml --syntax-check
+ansible-playbook tests/sudoers-scope.yml
 ```
 
 ### Additional Distributions

--- a/tests/sudoers-scope.yml
+++ b/tests/sudoers-scope.yml
@@ -1,0 +1,55 @@
+---
+- name: Verify scoped sudoers argument pins
+  hosts: localhost
+  connection: local
+  gather_facts: false
+
+  vars:
+    openclaw_user_tasks: "{{ playbook_dir }}/../roles/openclaw/tasks/user.yml"
+    forbidden_sudoers_cmds:
+      - /usr/bin/tailscale up *
+      - /usr/bin/journalctl -u openclaw *
+    required_sudoers_cmds:
+      - /usr/bin/tailscale up
+      - /usr/bin/journalctl -u openclaw
+      - /usr/bin/journalctl -u openclaw -f
+      - /usr/bin/journalctl -u openclaw -n 50
+      - /usr/bin/journalctl -u openclaw --no-pager
+      - /usr/bin/journalctl -u openclaw -n 50 --no-pager
+      - /usr/bin/journalctl -u openclaw -f --no-pager
+
+  tasks:
+    - name: Load service-user task file
+      ansible.builtin.slurp:
+        src: "{{ openclaw_user_tasks }}"
+      register: openclaw_user_tasks_file
+
+    - name: Decode service-user task file
+      ansible.builtin.set_fact:
+        openclaw_user_tasks_text: "{{ openclaw_user_tasks_file.content | b64decode }}"
+
+    - name: Collect NOPASSWD command specifications
+      ansible.builtin.set_fact:
+        openclaw_sudoers_cmds: >-
+          {{
+            openclaw_user_tasks_text.splitlines()
+            | map('trim')
+            | select('search', 'NOPASSWD:')
+            | map('regex_replace', '^.*NOPASSWD:\s*', '')
+            | list
+          }}
+
+    - name: Assert argument wildcards are not granted
+      ansible.builtin.assert:
+        that:
+          - item not in openclaw_sudoers_cmds
+        fail_msg: >-
+          sudoers still allows {{ item }}. Pin exact safe invocations.
+      loop: "{{ forbidden_sudoers_cmds }}"
+
+    - name: Assert pinned safe invocations are present
+      ansible.builtin.assert:
+        that:
+          - item in openclaw_sudoers_cmds
+        fail_msg: "sudoers is missing pinned command {{ item }}"
+      loop: "{{ required_sudoers_cmds }}"


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a compromised `openclaw` service user could reconfigure the host VPN or read other systemd journals through passwordless sudo. The default install writes `/etc/sudoers.d/openclaw` with `tailscale up *` and `journalctl -u openclaw *`. sudoers treats `*` as a glob for extra arguments, so `sudo tailscale up --advertise-exit-node` and `sudo journalctl -u openclaw -u sshd` (or `--directory` / `--file` / `--root`) were allowed. Operators who installed the playbook and later had the service account compromised would lose the scoped-sudo boundary those comments claimed to provide.

## Why This Change Was Made

Pin the two rules to the exact invocations this role documents: bare `tailscale up` (stored settings only) and `journalctl -u openclaw` with `-f`, `-n 50`, and `--no-pager`. Extra Tailscale flags and extra journalctl units stay root-only. This matches the pin style already used on #52 for `tailscale serve` and `--operator=`. It does not wire authkey connect or operator mode.

## User Impact

After install, the service user can still bring Tailscale up with saved settings and follow OpenClaw logs. They can no longer advertise an exit node, join a different tailnet, or read sshd (or any other unit) through sudo journalctl. Operators who need a wider `up` command can still add a root-managed sudoers line; the file comments keep that opt-in example.

## Evidence

terminal output from the patched tree at `/tmp/oc-pr-ansible-sudoers` (branch `fix/sudoers-pin-wildcards`).

Before the pin, the focused playbook rejected the default sudoers task:

```console
$ ansible-playbook tests/sudoers-scope.yml
TASK [Assert argument wildcards are not granted]
failed: [localhost] (item=/usr/bin/tailscale up *) => {
    "msg": "sudoers still allows /usr/bin/tailscale up *. Pin exact safe invocations."
}
failed: [localhost] (item=/usr/bin/journalctl -u openclaw *) => {
    "msg": "sudoers still allows /usr/bin/journalctl -u openclaw *. Pin exact safe invocations."
}
localhost  ok=3  failed=1
```

After the pin, the same command and visudo both accept the rendered snippet (`openclaw_user=openclaw`):

```console
$ ansible-playbook tests/sudoers-scope.yml
TASK [Assert argument wildcards are not granted]
ok: [localhost] => (item=/usr/bin/tailscale up *)
ok: [localhost] => (item=/usr/bin/journalctl -u openclaw *)
TASK [Assert pinned safe invocations are present]
ok: [localhost] => (item=/usr/bin/tailscale up)
ok: [localhost] => (item=/usr/bin/journalctl -u openclaw)
ok: [localhost] => (item=/usr/bin/journalctl -u openclaw -f)
ok: [localhost] => (item=/usr/bin/journalctl -u openclaw -n 50)
ok: [localhost] => (item=/usr/bin/journalctl -u openclaw --no-pager)
PLAY RECAP localhost  ok=5  changed=0  failed=0
```

```console
$ visudo -cf /tmp/sudoers-openclaw-rendered
/tmp/sudoers-openclaw-rendered: parsed OK
```

Rendered sudoers commands after the pin:

```
openclaw ALL=(ALL) NOPASSWD: /usr/bin/tailscale up
openclaw ALL=(ALL) NOPASSWD: /usr/bin/journalctl -u openclaw
openclaw ALL=(ALL) NOPASSWD: /usr/bin/journalctl -u openclaw -f
openclaw ALL=(ALL) NOPASSWD: /usr/bin/journalctl -u openclaw -n 50
openclaw ALL=(ALL) NOPASSWD: /usr/bin/journalctl -u openclaw --no-pager
openclaw ALL=(ALL) NOPASSWD: /usr/bin/journalctl -u openclaw -n 50 --no-pager
openclaw ALL=(ALL) NOPASSWD: /usr/bin/journalctl -u openclaw -f --no-pager
```

yamllint on the changed YAML files exited 0. ansible-lint (production profile) reported 0 failures on `playbook.yml`, `tests/docker-group-security.yml`, and `tests/sudoers-scope.yml`. `ansible-playbook playbook.yml --syntax-check` and `ansible-playbook tests/sudoers-scope.yml --syntax-check` both exited 0.

## Real behavior proof

- **Behavior or issue addressed:** Default sudoers wildcards let a compromised openclaw user reconfigure Tailscale or read other journal units. The role now writes exact `tailscale up` and `journalctl -u openclaw` invocations only.
- **Real environment tested:** macOS host, Python 3.14.7, ansible-core 2.21.3 from `/tmp/ansible-lint-env`, worktree `/tmp/oc-pr-ansible-sudoers` on `fix/sudoers-pin-wildcards`. visudo from the host validated the rendered snippet.
- **Exact steps or command run after this patch:**

  ```
  ansible-playbook tests/sudoers-scope.yml
  python3 render-sudoers.py
  visudo -cf /tmp/sudoers-openclaw-rendered
  ansible-playbook playbook.yml --syntax-check
  ```

- **Evidence after fix:** terminal output from the patched worktree is in the Evidence section above: the playbook reports `failed=0` for the wildcard asserts, visudo prints `parsed OK`, and the rendered file contains bare `tailscale up` plus the six journalctl pins with no `up *` or `journalctl -u openclaw *`.
- **Observed result after fix:** The focused playbook no longer sees the two argument globs. visudo accepts the rendered `/etc/sudoers.d/openclaw` body. Extra flags such as `--advertise-exit-node` or a second `-u sshd` are not in the granted command list.
- **What was not tested:** A live Debian VM with an interactive openclaw login running the denied sudo commands. Diagnostic `tailscale ip *` / `ping *` / `whois *` lines are unchanged on purpose.

## Related

- Same-repo pin precedent: #52 narrowed `tailscale serve *` and `--operator=*` in this same sudoers file. That PR is authkey/operator wiring; this change does not take over that work.
- sudoers wildcards are POSIX globs (`*`, `?`, `[]`), so a trailing `*` matches extra argv: https://www.sudo.ws/docs/man/sudoers.man.html
- Introduced with the scoped sudoers block (`1f605546` / `65c272a5`, 2026-02) and still present on current `main`.
