### PR TITLE
fix: complete installs and keep repeated runs idempotent

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -91,3 +91,14 @@ jobs:
 
       - name: Verify service-user Docker access is removed
         run: ansible-playbook tests/docker-group-security.yml
+
+  installer-integration:
+    name: Installer Integration
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Verify installation, configuration, and idempotency
+        run: bash tests/run-tests.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fix local installation failing after package setup by removing tasks that reference the deleted banner template; run the Docker installer harness in CI.
 - Remove unused configuration, service, and banner templates; document the native Gateway and onboarding-owned security configuration accurately. Thanks @tosin2013 for the report.
 - Update the Ansible lint toolchain and GitHub Actions dependencies, with Python 3.14 for CI.
 - Exclude checkout metadata and local Ansible caches from Docker test images so the harness also works from Git worktrees.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix local installation failing after package setup by removing tasks that reference the deleted banner template; run the Docker installer harness in CI.
+- Reuse fresh apt metadata on repeated installations while refreshing immediately when the NodeSource repository is added.
 - Remove unused configuration, service, and banner templates; document the native Gateway and onboarding-owned security configuration accurately. Thanks @tosin2013 for the report.
 - Update the Ansible lint toolchain and GitHub Actions dependencies, with Python 3.14 for CI.
 - Exclude checkout metadata and local Ansible caches from Docker test images so the harness also works from Git worktrees.

--- a/playbooks/install.yml
+++ b/playbooks/install.yml
@@ -88,16 +88,6 @@
     - openclaw
 
   post_tasks:
-    - name: Copy ASCII art script
-      ansible.builtin.template:
-        src: "{{ playbook_dir }}/../roles/openclaw/templates/show-lobster.sh.j2"
-        dest: /tmp/show-lobster.sh
-        mode: '0755'
-
-    - name: Display ASCII art
-      ansible.builtin.command: /tmp/show-lobster.sh
-      changed_when: false
-
     - name: Create one-time welcome message for openclaw user
       ansible.builtin.copy:
         dest: "{{ openclaw_home }}/.openclaw-welcome"

--- a/roles/openclaw/tasks/nodejs.yml
+++ b/roles/openclaw/tasks/nodejs.yml
@@ -32,10 +32,13 @@
         tee /etc/apt/sources.list.d/nodesource.list > /dev/null
     creates: /etc/apt/sources.list.d/nodesource.list
     executable: /bin/bash
+  register: openclaw_nodesource_repository
 
 - name: Update apt cache after adding NodeSource repo
   ansible.builtin.apt:
     update_cache: true
+    # A newly added source needs an immediate refresh even when other lists are fresh.
+    cache_valid_time: "{{ 0 if openclaw_nodesource_repository.changed else 3600 }}"
 
 - name: Install Node.js
   ansible.builtin.apt:

--- a/roles/openclaw/tasks/system-tools-linux.yml
+++ b/roles/openclaw/tasks/system-tools-linux.yml
@@ -44,6 +44,7 @@
       - file
     state: present
     update_cache: true
+    cache_valid_time: 3600
 
 - name: Deploy global vim configuration (Linux)
   ansible.builtin.template:

--- a/roles/openclaw/tasks/system-tools-linux.yml
+++ b/roles/openclaw/tasks/system-tools-linux.yml
@@ -1,6 +1,12 @@
 ---
 # Linux-specific system tools installation (apt-based)
 
+- name: Check for populated apt package lists
+  ansible.builtin.find:
+    paths: /var/lib/apt/lists
+    patterns: '*_Packages*'
+  register: openclaw_apt_package_lists
+
 - name: Install essential system tools (Linux - apt)
   ansible.builtin.apt:
     name:
@@ -44,7 +50,8 @@
       - file
     state: present
     update_cache: true
-    cache_valid_time: 3600
+    # Clean container images can have a recent lists directory with no package indexes.
+    cache_valid_time: "{{ 3600 if openclaw_apt_package_lists.matched > 0 else 0 }}"
 
 - name: Deploy global vim configuration (Linux)
   ansible.builtin.template:

--- a/tests/README.md
+++ b/tests/README.md
@@ -2,6 +2,8 @@
 
 This directory contains a Docker-based CI test harness for the Ansible playbook. It validates convergence, correctness, and idempotency by running the playbook inside an Ubuntu 24.04 container.
 
+The Lint workflow runs this harness in its Installer Integration job on pushes and pull requests, alongside lint, syntax, and Docker-group security checks.
+
 ## Quick Start
 
 ```bash


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where local installations fail after package setup, before the final welcome instructions appear, and repeated installations can unnecessarily refresh apt metadata.

## Why This Change Was Made

The installation playbook still rendered a deleted banner template. Remove those obsolete tasks and run the existing Docker convergence, verification, and idempotency harness in CI. The new job exposed an unconditional NodeSource apt refresh, which could make the second run report a change solely because repository metadata changed.

Reuse populated apt metadata for one hour. Refresh immediately when package indexes are missing or NodeSource is first added: clean container images can have a recent apt directory timestamp despite containing no indexes. The zero-change assertion remains intact.

Dependency audit: no version changes were necessary. Exact pins are current: ansible-core 2.21.3, ansible-lint 26.8.0, yamllint 1.38.0, actions/checkout 7.0.1, actions/setup-python 7.0.0, and actions/create-github-app-token 3.2.0. All action SHAs match their release tags. Galaxy ranges admit community.docker 5.2.2, community.general 13.3.0, and ansible.posix 2.2.2. pnpm and OpenClaw already use latest-release installation commands. No dependencies were added or removed; there are no lockfiles to regenerate.

Node 22 remains the default pending a platform-support decision: [Node 24 removes Linux ARMv7 binaries](https://nodejs.org/en/blog/migrations/v22-to-v24). Recommend explicitly documenting supported architectures before changing that default. [Node 26 is still Current rather than LTS](https://nodejs.org/en/about/previous-releases), so it is not proposed for the production installer.

## User Impact

Installation completes and presents its onboarding instructions. Repeated runs reuse fresh apt metadata, and CI requires the second installation run to make zero changes.

## Evidence

[All five CI jobs pass on 65f4325](https://github.com/openclaw/openclaw-ansible/actions/runs/33372081975): YAML Lint, Ansible Lint, Ansible Syntax Check, Docker Group Security, and Installer Integration.

Full Docker build and live Ubuntu 24.04 installer integration on that commit:

```text
bash tests/run-tests.sh

Node.js version: v22.23.2
pnpm version: 11.24.0
OpenClaw installed from npm: OpenClaw 2026.7.1 (2d2ddc4)
localhost : ok=53 changed=21 unreachable=0 failed=0 skipped=19 rescued=0 ignored=0
===> Convergence: PASSED
localhost : ok=13 changed=0 unreachable=0 failed=0 skipped=0 rescued=0 ignored=0
===> Verification: PASSED
localhost : ok=51 changed=0 unreachable=0 failed=0 skipped=21 rescued=0 ignored=0
===> Idempotency: PASSED (0 changed)
===> All tests passed
```

Local YAML lint, Bash syntax, Ansible syntax, and Ansible lint passed during development; the final apt-index guard also passed YAML parsing. Local lint used a source-linked collection after temporary files inside the checkout interfered with collection packaging. The final clean-checkout CI run passed the normal lint path. Codex autoreview of the full final diff completed scoped-clean with no accepted/actionable findings at its default priority.

The banner correction also passed the full harness in a disposable Linux VM with `CRABBOX_ENV_ALLOW=CI crabbox run --no-hydrate --timing-json -- bash tests/run-tests.sh`. Local macOS Docker container creation stalled, so full runtime proof used that VM and CI; the shared Docker service was not restarted. The existing `ci_test=true` mode excludes firewall, Docker daemon installation, and systemd services from this proof.

CI reasoning: the orchestrator reported NORUNS, but the latest default-branch [Lint run was already green](https://github.com/openclaw/openclaw-ansible/actions/runs/33158725503). Its four jobs omitted installer convergence. The [first PR run](https://github.com/openclaw/openclaw-ansible/actions/runs/33371115732) exposed the apt-refresh idempotency failure; the [second](https://github.com/openclaw/openclaw-ansible/actions/runs/33371574298) exposed the empty-cache timestamp case. Both are fixed in the passing final run. ClawSweeper Dispatch is separate operational automation and is unchanged.
