### PR TITLE
fix(install): require Ansible 2.14 after apt install

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -74,6 +74,16 @@ jobs:
           ansible-playbook playbook.yml --syntax-check
           ansible-playbook tests/docker-group-security.yml --syntax-check
 
+  install-ansible-version:
+    name: Installer Ansible Version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Reject old ansible-playbook from install.sh
+        run: bash tests/install-ansible-version.sh
+
   docker-group-security:
     name: Docker Group Security
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Fail closed in `install.sh` when `ansible-playbook` is older than ansible-core 2.14, which the collection requires. Ubuntu 22.04 and Debian 11 apt packages stay unsupported unless pip or the Ansible PPA provides 2.14+.
 - Fix local installation failing after package setup by removing tasks that reference the deleted banner template; run the Docker installer harness in CI.
 - Reuse fresh apt metadata on repeated installations while refreshing immediately when the NodeSource repository is added.
 - Remove unused configuration, service, and banner templates; document the native Gateway and onboarding-owned security configuration accurately. Thanks @tosin2013 for the report.

--- a/README.md
+++ b/README.md
@@ -279,9 +279,13 @@ ansible-playbook playbook.yml --ask-become-pass
 
 ## Requirements
 
-- Debian 11+ or Ubuntu 20.04+
+- Debian 12+ or Ubuntu 24.04+ (apt `ansible-core` 2.14 or newer)
 - Root/sudo access
 - Internet connection
+
+On Ubuntu 22.04 or Debian 11, install `ansible-core` 2.14 or newer via `pip3`
+or the Ansible PPA before running `install.sh`. Distro `apt` ansible on those
+releases is older than `requires_ansible: '>=2.14.0'`.
 
 ## Configuration Options
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -15,9 +15,21 @@ curl -fsSL https://raw.githubusercontent.com/openclaw/openclaw-ansible/main/inst
 
 ### Prerequisites
 
+Ansible-core 2.14 or newer is required (`meta/runtime.yml`). On Debian 12+ and
+Ubuntu 24.04+, the distro package is new enough:
+
 ```bash
 sudo apt update
 sudo apt install -y ansible git
+ansible-playbook --version   # first line must show [core 2.14] or newer
+```
+
+On Ubuntu 22.04, Debian 11, and Ubuntu 20.04, `apt install ansible` ships
+2.10 / ansible-core 2.12. Install a current controller first:
+
+```bash
+pip3 install --user 'ansible-core>=2.14'
+# or add the Ansible PPA and install ansible-core
 ```
 
 ### Clone and Run

--- a/install.sh
+++ b/install.sh
@@ -19,6 +19,67 @@ YELLOW='\033[1;33m'
 BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
+# Collection requires ansible-core >=2.14 (meta/runtime.yml). Distro apt
+# ansible on Ubuntu 22.04 / Debian 11 is older; fail closed instead of
+# adding a PPA from curl|bash.
+MIN_ANSIBLE_CORE="2.14.0"
+
+ansible_core_version_from_banner() {
+    local banner="$1"
+    if [[ "$banner" =~ \[core[[:space:]]+([0-9]+)\.([0-9]+)(\.([0-9]+))? ]]; then
+        printf '%s.%s.%s' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[4]:-0}"
+        return 0
+    fi
+    if [[ "$banner" =~ ansible-playbook[[:space:]]+([0-9]+)\.([0-9]+)(\.([0-9]+))? ]]; then
+        printf '%s.%s.%s' "${BASH_REMATCH[1]}" "${BASH_REMATCH[2]}" "${BASH_REMATCH[4]:-0}"
+        return 0
+    fi
+    return 1
+}
+
+version_ge() {
+    local -a have need
+    local i h n
+    IFS=. read -r -a have <<<"$1"
+    IFS=. read -r -a need <<<"$2"
+    for i in 0 1 2; do
+        h="${have[i]:-0}"
+        n="${need[i]:-0}"
+        if ((10#$h > 10#$n)); then
+            return 0
+        fi
+        if ((10#$h < 10#$n)); then
+            return 1
+        fi
+    done
+    return 0
+}
+
+require_ansible_core() {
+    local banner version first_line
+    if ! banner="$(ansible-playbook --version 2>&1)"; then
+        echo -e "${RED}Error: ansible-playbook --version failed.${NC}"
+        echo -e "${RED}  Install ansible-core ${MIN_ANSIBLE_CORE} or newer, then re-run.${NC}"
+        exit 1
+    fi
+    first_line="${banner%%$'\n'*}"
+    if ! version="$(ansible_core_version_from_banner "$banner")"; then
+        version=""
+    fi
+    if [ -z "$version" ] || ! version_ge "$version" "$MIN_ANSIBLE_CORE"; then
+        echo -e "${RED}Error: ansible-playbook is older than ansible-core ${MIN_ANSIBLE_CORE}.${NC}"
+        echo -e "${RED}  Found: ${first_line}${NC}"
+        echo -e "${RED}  This collection requires ansible-core ${MIN_ANSIBLE_CORE}+ (meta/runtime.yml).${NC}"
+        echo -e "${RED}  Debian 11 and Ubuntu 20.04/22.04 apt ansible is too old.${NC}"
+        echo -e "${YELLOW}  Install a current controller, then re-run:${NC}"
+        echo -e "${YELLOW}    pip3 install --user 'ansible-core>=2.14'${NC}"
+        echo -e "${YELLOW}    # or add the Ansible PPA and install ansible-core${NC}"
+        echo -e "${YELLOW}    # or use Debian 12+ / Ubuntu 24.04+, where apt meets 2.14${NC}"
+        exit 1
+    fi
+    echo -e "${GREEN}✓ ansible-playbook ${version} meets ansible-core ${MIN_ANSIBLE_CORE}+${NC}"
+}
+
 echo -e "${GREEN}╔════════════════════════════════════════╗${NC}"
 echo -e "${GREEN}║   OpenClaw Ansible Installer           ║${NC}"
 echo -e "${GREEN}╚════════════════════════════════════════╝${NC}"
@@ -66,6 +127,8 @@ else
         echo -e "${GREEN}✓ git already installed${NC}"
     fi
 fi
+
+require_ansible_core
 
 echo -e "${GREEN}[2/3] Installing OpenClaw collection...${NC}"
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -28,6 +28,7 @@ The test harness runs three sequential tests:
 - `entrypoint.sh` - Test execution script (convergence → verification → idempotency)
 - `verify.yml` - Post-convergence assertions (user exists, packages installed, directories created, etc.)
 - `run-tests.sh` - Local test runner script
+- `install-ansible-version.sh` - Drive `install.sh` with a mocked `ansible-playbook` and require ansible-core 2.14+
 
 ## CI Test Mode
 

--- a/tests/install-ansible-version.sh
+++ b/tests/install-ansible-version.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# Drive install.sh with a mocked ansible-playbook so old controllers fail
+# closed and ansible-core 2.14+ is accepted.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALL_SH="${ROOT}/install.sh"
+WORKDIR="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-ansible-ver.XXXXXX")"
+trap 'rm -rf "$WORKDIR"' EXIT
+
+BIN="${WORKDIR}/bin"
+mkdir -p "$BIN"
+
+failures=0
+
+write_exec() {
+    local path="$1"
+    cat >"$path"
+    chmod +x "$path"
+}
+
+write_ansible_playbook() {
+    local version_banner="$1"
+    write_exec "${BIN}/ansible-playbook" <<EOF
+#!/usr/bin/env bash
+if [[ " \$* " == *" --version "* ]] || [[ "\$1" == "--version" ]]; then
+    printf '%s\n' $(printf '%q' "$version_banner")
+    printf '  config file = None\n'
+    exit 0
+fi
+printf 'playbook invoked: %s\n' "\$*"
+exit 0
+EOF
+}
+
+write_support_bins() {
+    write_exec "${BIN}/apt-get" <<'EOF'
+#!/usr/bin/env bash
+printf 'unexpected apt-get: %s\n' "$*" >&2
+exit 42
+EOF
+    write_exec "${BIN}/sudo" <<'EOF'
+#!/usr/bin/env bash
+exec "$@"
+EOF
+    write_exec "${BIN}/ansible-galaxy" <<'EOF'
+#!/usr/bin/env bash
+printf 'galaxy mocked: %s\n' "$*"
+exit 0
+EOF
+}
+
+run_install() {
+    local banner="$1"
+    write_support_bins
+    write_ansible_playbook "$banner"
+    env -u ANSIBLE_EXTRA_VARS \
+        PATH="${BIN}:${PATH}" \
+        bash "$INSTALL_SH" 2>&1
+}
+
+expect_reject() {
+    local name="$1"
+    local banner="$2"
+    local out rc
+    set +e
+    out="$(run_install "$banner")"
+    rc=$?
+    set -e
+    if [ "$rc" -eq 0 ]; then
+        printf 'FAIL %s: expected install.sh to reject %s (exit 0)\n' "$name" "$banner" >&2
+        printf '%s\n' "$out" >&2
+        failures=$((failures + 1))
+        return
+    fi
+    if ! printf '%s\n' "$out" | grep -q 'ansible-core 2.14'; then
+        printf 'FAIL %s: missing ansible-core 2.14 error\n' "$name" >&2
+        printf '%s\n' "$out" >&2
+        failures=$((failures + 1))
+        return
+    fi
+    if printf '%s\n' "$out" | grep -q 'playbook invoked:'; then
+        printf 'FAIL %s: playbook ran after version reject\n' "$name" >&2
+        printf '%s\n' "$out" >&2
+        failures=$((failures + 1))
+        return
+    fi
+    printf 'OK   %s (exit %s)\n' "$name" "$rc"
+}
+
+expect_accept() {
+    local name="$1"
+    local banner="$2"
+    local out rc
+    set +e
+    out="$(run_install "$banner")"
+    rc=$?
+    set -e
+    if [ "$rc" -ne 0 ]; then
+        printf 'FAIL %s: expected install.sh to accept %s (exit %s)\n' "$name" "$banner" "$rc" >&2
+        printf '%s\n' "$out" >&2
+        failures=$((failures + 1))
+        return
+    fi
+    if ! printf '%s\n' "$out" | grep -q 'playbook invoked:'; then
+        printf 'FAIL %s: playbook did not run after version accept\n' "$name" >&2
+        printf '%s\n' "$out" >&2
+        failures=$((failures + 1))
+        return
+    fi
+    printf 'OK   %s (exit %s)\n' "$name" "$rc"
+}
+
+expect_reject "ubuntu-2204-ansible-2.10" "ansible-playbook 2.10.8"
+expect_reject "ubuntu-2204-core-2.12" "ansible-playbook [core 2.12.0]"
+expect_reject "debian-11-ansible-2.10" "ansible-playbook 2.10.17"
+expect_reject "unparseable-banner" "ansible-playbook (devel build)"
+expect_accept "exact-core-2.14.0" "ansible-playbook [core 2.14.0]"
+expect_accept "ubuntu-2404-core-2.16" "ansible-playbook [core 2.16.3]"
+
+if [ "$failures" -ne 0 ]; then
+    printf '\n%s check(s) failed\n' "$failures" >&2
+    exit 1
+fi
+
+printf '\nAll ansible-playbook version checks passed\n'


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running the public curl|bash installer on Ubuntu 22.04, Ubuntu 20.04, or Debian 11 would get `apt-get install -y ansible git`, then fail later when the collection loaded. `meta/runtime.yml` requires ansible-core 2.14 or newer. Those distros still ship ansible 2.10 or ansible-core 2.12. The failure happened after Galaxy install, with a controller-version error instead of a prerequisite message.

## Why This Change Was Made

After apt install (or when ansible-playbook is already on PATH), `install.sh` now reads `ansible-playbook --version` and exits if the controller is older than 2.14.0 or the banner cannot be parsed. The installer does not add a PPA from curl|bash. README now lists Debian 12+ / Ubuntu 24.04+ as the apt-supported matrix; older releases can still run if they provide ansible-core 2.14+ via pip or the Ansible PPA.

## User Impact

curl|bash and the manual `apt install ansible` path fail immediately with the found version and install hints, instead of installing the collection and then aborting. Ubuntu 24.04 and Debian 12 users are unchanged when apt already meets 2.14.

## Evidence

Public path is `install.sh` on a live Ubuntu 22.04.5 LTS container. Distro apt installed `ansible` 2.10.7+merged+base+2.10.8 (real `ansible-playbook 2.10.8` at `/usr/bin/ansible-playbook`).

Unpatched `main` `install.sh` does not reject that controller. It prints Ansible already installed and starts Galaxy:

```console
$ cat /etc/os-release | grep PRETTY
PRETTY_NAME="Ubuntu 22.04.5 LTS"

$ ansible-playbook --version | head -1
ansible-playbook 2.10.8

$ bash /tmp/install-main.sh
[1/3] Checking prerequisites...
Ansible already installed
git already installed
[2/3] Installing OpenClaw collection...
Starting galaxy collection install process
Process install dependency map
```

Patched `install.sh` on the same host exits 1 before Galaxy:

```console
$ bash /tmp/install-patched.sh
[1/3] Checking prerequisites...
Ansible already installed
git already installed
Error: ansible-playbook is older than ansible-core 2.14.0.
  Found: ansible-playbook 2.10.8
  This collection requires ansible-core 2.14.0+ (meta/runtime.yml).
  Debian 11 and Ubuntu 20.04/22.04 apt ansible is too old.
install.sh exit=1
```

Recovery on that same host: `pip3 install 'ansible-core>=2.14,<2.17'`, then re-run the patched installer. The gate accepts core 2.16.19 and continues to Galaxy:

```console
$ ansible-playbook --version | head -1
ansible-playbook [core 2.16.19]

$ bash /tmp/install-patched.sh
[1/3] Checking prerequisites...
ansible-playbook 2.16.19 meets ansible-core 2.14.0+
[2/3] Installing OpenClaw collection...
Cloning into '.../openclaw-ansible...'
```

Origin: `apt-get install -y ansible git` landed in https://github.com/openclaw/openclaw-ansible/pull/40 (722f3d74, 2026-03-09) when the repo became a Galaxy collection with `requires_ansible: '>=2.14.0'`.

## Real behavior proof

- **Behavior or issue addressed:** curl|bash install.sh accepted apt or preinstalled ansible-playbook older than ansible-core 2.14, then continued into Galaxy instead of stopping with a prerequisite message.
- **Real environment tested:** Docker `ubuntu:22.04` (Ubuntu 22.04.5 LTS, arm64). Distro `apt-get install -y ansible git` produced `ansible-playbook 2.10.8`. Patched installer from commit `c4747c9467`. Unpatched installer from current `main`.
- **Exact steps or command run after this patch:**

  ```bash
  docker run -d --name oc74-proof ubuntu:22.04 sleep 7200
  docker exec oc74-proof bash -lc 'apt-get update && apt-get install -y ansible git python3-pip'
  docker exec oc74-proof ansible-playbook --version
  docker cp install.sh oc74-proof:/tmp/install-patched.sh
  docker exec oc74-proof bash /tmp/install-patched.sh
  docker cp main/install.sh oc74-proof:/tmp/install-main.sh
  docker exec oc74-proof bash /tmp/install-main.sh
  docker exec oc74-proof pip3 install 'ansible-core>=2.14,<2.17'
  docker exec oc74-proof bash /tmp/install-patched.sh
  ```

- **Evidence after fix:** terminal output from the live Ubuntu 22.04 host.

  Distro controller is rejected before Galaxy:

  ```console
  $ ansible-playbook --version | head -1
  ansible-playbook 2.10.8
  $ bash /tmp/install-patched.sh
  Error: ansible-playbook is older than ansible-core 2.14.0.
    Found: ansible-playbook 2.10.8
  install.sh exit=1
  ```

  Unpatched `main` on the same host does not reject and starts Galaxy:

  ```console
  $ bash /tmp/install-main.sh
  [1/3] Checking prerequisites...
  Ansible already installed
  [2/3] Installing OpenClaw collection...
  Starting galaxy collection install process
  ```

  After `pip3 install` of ansible-core 2.16.19, the same patched installer continues:

  ```console
  $ ansible-playbook --version | head -1
  ansible-playbook [core 2.16.19]
  $ bash /tmp/install-patched.sh
  ansible-playbook 2.16.19 meets ansible-core 2.14.0+
  [2/3] Installing OpenClaw collection...
  Cloning into '.../openclaw-ansible...'
  ```

- **Observed result after fix:** On Ubuntu 22.04.5 with apt ansible-playbook 2.10.8, patched install.sh exits 1 before Galaxy. Unpatched main proceeds to Galaxy. After upgrading to ansible-core 2.16.19 on that host, patched install.sh prints that 2.16.19 meets 2.14.0+ and starts the collection clone.
- **What was not tested:** Debian 11 and Ubuntu 20.04 apt packages. Ansible PPA install. A full OpenClaw playbook provision (Docker, Tailscale, host services).

## Summary

Related collection metadata: `meta/runtime.yml` (`requires_ansible: '>=2.14.0'`). Bug introduced with the Galaxy collection conversion in https://github.com/openclaw/openclaw-ansible/pull/40. Open PR https://github.com/openclaw/openclaw-ansible/pull/71 is the leftover sudoers-wildcard work, not this version gate.

Hard reject matches that collection contract. It fails earlier than Galaxy or playbook load, with install hints. Maintainer call: keep this fail-closed default, or switch to warn-only unless an explicit strict flag is set.
